### PR TITLE
Fix currency dropdown, entry flow state, and mock amount

### DIFF
--- a/lib/data/mock/mock_repositories.dart
+++ b/lib/data/mock/mock_repositories.dart
@@ -248,7 +248,7 @@ class OperationsRepository {
       ),
       Operation(
         id: 'operation-${_idCounter++}',
-        amount: 2500 + random.nextInt(500),
+        amount: 2500.0 + random.nextInt(500).toDouble(),
         type: OperationType.expense,
         category: fun,
         date: now.subtract(const Duration(days: 3)),

--- a/lib/state/entry_flow_providers.dart
+++ b/lib/state/entry_flow_providers.dart
@@ -5,7 +5,7 @@ import '../data/mock/mock_models.dart';
 const bool kReturnToOperationsAfterSave = true;
 
 class EntryFlowState {
-  const EntryFlowState({
+  EntryFlowState({
     this.amountInput = '',
     this.type = OperationType.expense,
     this.category,
@@ -61,7 +61,7 @@ class EntryFlowState {
 }
 
 class EntryFlowController extends StateNotifier<EntryFlowState> {
-  EntryFlowController() : super(const EntryFlowState());
+  EntryFlowController() : super(EntryFlowState());
 
   void startNew({OperationType type = OperationType.expense}) {
     state = EntryFlowState(type: type);
@@ -133,7 +133,7 @@ class EntryFlowController extends StateNotifier<EntryFlowState> {
   }
 
   void reset() {
-    state = const EntryFlowState();
+    state = EntryFlowState();
   }
 }
 

--- a/lib/ui/settings/settings_placeholder.dart
+++ b/lib/ui/settings/settings_placeholder.dart
@@ -75,7 +75,7 @@ class _SettingsPlaceholderState extends ConsumerState<SettingsPlaceholder> {
                     items: const [
                       DropdownMenuItem(value: '₽', child: Text('Российский рубль (₽)')),
                       DropdownMenuItem(value: '€', child: Text('Евро (€)')),
-                      DropdownMenuItem(value: '$', child: Text('Доллар США ($)')),
+                      DropdownMenuItem(value: r'$', child: Text(r'Доллар США ($)')),
                     ],
                     onChanged: (value) {
                       if (value != null) {


### PR DESCRIPTION
## Summary
- escape the dollar currency dropdown item using raw strings
- make the entry flow state constructor non-const and update controller resets
- ensure mock operation amounts use doubles when adding random values

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7db33a9883268df889c3f0d784d2