### PR TITLE
Update UI period selector and calculator keypad

### DIFF
--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -156,6 +156,7 @@ class ScaffoldWithNavigationShell extends ConsumerWidget {
 
     return Scaffold(
       body: navigationShell,
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       floatingActionButton: isHomeTab
           ? Semantics(
               button: true,

--- a/lib/ui/entry/amount_screen.dart
+++ b/lib/ui/entry/amount_screen.dart
@@ -16,9 +16,14 @@ class AmountScreen extends ConsumerWidget {
     final entryState = ref.watch(entryFlowControllerProvider);
     final controller = ref.read(entryFlowControllerProvider.notifier);
 
-    final formattedAmount = entryState.amount > 0
-        ? formatCurrency(entryState.amount)
-        : formatCurrency(0);
+    final previewResult = entryState.previewResult;
+    final result = entryState.result;
+    final amountValue = result ?? previewResult ?? 0;
+    final formattedAmount = formatCurrency(amountValue);
+    final expression = entryState.expression;
+    final expressionDisplay = expression.isEmpty
+        ? '0'
+        : expression.replaceAll('*', '×').replaceAll('/', '÷');
 
     return Scaffold(
       appBar: AppBar(
@@ -57,6 +62,12 @@ class AmountScreen extends ConsumerWidget {
               child: Column(
                 children: [
                   Text(
+                    expressionDisplay,
+                    style: Theme.of(context).textTheme.titleLarge,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
                     formattedAmount,
                     style: Theme.of(context)
                         .textTheme
@@ -90,13 +101,27 @@ class AmountScreen extends ConsumerWidget {
               ],
             ),
             const SizedBox(height: 24),
+            if (expression.isNotEmpty && previewResult != null && result == null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  '= ${formatCurrency(previewResult)}',
+                  textAlign: TextAlign.right,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(color: Theme.of(context).hintColor),
+                ),
+              ),
             Expanded(
               child: SingleChildScrollView(
                 child: AmountKeypad(
                   onDigitPressed: controller.appendDigit,
+                  onOperatorPressed: controller.appendOperator,
+                  onDecimal: controller.appendDecimal,
+                  onAllClear: controller.clear,
                   onBackspace: controller.backspace,
-                  onDecimal: controller.appendSeparator,
-                  onClear: controller.clear,
+                  onEvaluate: controller.evaluateExpression,
                 ),
               ),
             ),

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -44,24 +44,30 @@ class HomeScreen extends ConsumerWidget {
             CalloutCard(
               title: 'Запланировано',
               subtitle: 'Быстрый доступ к будущим операциям',
-              child: Wrap(
-                spacing: 12,
-                runSpacing: 12,
+              child: Column(
                 children: [
-                  FilledButton.tonalIcon(
-                    onPressed: () => context.pushNamed(RouteNames.plannedIncome),
-                    icon: const Icon(Icons.trending_up),
-                    label: const Text('Доходы'),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.trending_up),
+                    title: const Text('Доходы'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => context.pushNamed(RouteNames.plannedIncome),
                   ),
-                  FilledButton.tonalIcon(
-                    onPressed: () => context.pushNamed(RouteNames.plannedExpense),
-                    icon: const Icon(Icons.trending_down),
-                    label: const Text('Расходы'),
+                  const Divider(height: 0),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.trending_down),
+                    title: const Text('Расходы'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => context.pushNamed(RouteNames.plannedExpense),
                   ),
-                  FilledButton.tonalIcon(
-                    onPressed: () => context.pushNamed(RouteNames.plannedSavings),
-                    icon: const Icon(Icons.savings),
-                    label: const Text('Сбережения'),
+                  const Divider(height: 0),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.savings),
+                    title: const Text('Сбережения'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => context.pushNamed(RouteNames.plannedSavings),
                   ),
                 ],
               ),
@@ -152,11 +158,15 @@ class HomeScreen extends ConsumerWidget {
         CalloutCard(
           title: 'Осталось в этом бюджете',
           subtitle: formatCurrency(summary.remainingBudget),
+          borderless: true,
+          centered: true,
         ),
         const SizedBox(height: 12),
         CalloutCard(
           title: 'Осталось на день',
           subtitle: formatCurrency(summary.remainingPerDay),
+          borderless: true,
+          centered: true,
         ),
       ],
     );

--- a/lib/ui/widgets/amount_keypad.dart
+++ b/lib/ui/widgets/amount_keypad.dart
@@ -4,167 +4,150 @@ class AmountKeypad extends StatelessWidget {
   const AmountKeypad({
     super.key,
     required this.onDigitPressed,
+    required this.onOperatorPressed,
     required this.onBackspace,
     required this.onDecimal,
-    required this.onClear,
+    required this.onAllClear,
+    required this.onEvaluate,
   });
 
   final ValueChanged<String> onDigitPressed;
+  final ValueChanged<String> onOperatorPressed;
   final VoidCallback onBackspace;
   final VoidCallback onDecimal;
-  final VoidCallback onClear;
+  final VoidCallback onAllClear;
+  final VoidCallback onEvaluate;
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final buttonStyle = ElevatedButton.styleFrom(
       minimumSize: const Size(72, 64),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      textStyle: theme.textTheme.titleLarge,
     );
 
-    Widget buildButton(String label, VoidCallback onPressed) {
-      return ElevatedButton(
-        onPressed: onPressed,
-        style: buttonStyle,
-        child: Text(
-          label,
-          style: Theme.of(context).textTheme.headlineSmall,
+    final secondaryStyle = buttonStyle.copyWith(
+      backgroundColor: MaterialStatePropertyAll(
+        theme.colorScheme.surfaceVariant,
+      ),
+      foregroundColor: MaterialStatePropertyAll(
+        theme.colorScheme.onSurfaceVariant,
+      ),
+    );
+
+    final operatorStyle = buttonStyle.copyWith(
+      backgroundColor: MaterialStatePropertyAll(
+        theme.colorScheme.secondaryContainer,
+      ),
+      foregroundColor: MaterialStatePropertyAll(
+        theme.colorScheme.onSecondaryContainer,
+      ),
+    );
+
+    final evaluateStyle = buttonStyle.copyWith(
+      backgroundColor: MaterialStatePropertyAll(theme.colorScheme.primary),
+      foregroundColor: MaterialStatePropertyAll(theme.colorScheme.onPrimary),
+    );
+
+    Widget buildButton(
+      Widget child,
+      VoidCallback onPressed, {
+      int flex = 1,
+      ButtonStyle? style,
+    }) {
+      return Expanded(
+        flex: flex,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+          child: ElevatedButton(
+            onPressed: onPressed,
+            style: style ?? buttonStyle,
+            child: child,
+          ),
         ),
       );
     }
 
+    Widget buildRow(List<Widget> children) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            ...children,
+          ],
+        ),
+      );
+    }
+
+    Widget buildSpacer({int flex = 1}) {
+      return Expanded(flex: flex, child: const SizedBox.shrink());
+    }
+
     return Column(
       children: [
-        for (final row in _buttonRows)
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: row.map((button) {
-                switch (button) {
-                  case _KeypadButton.digit1:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('1', () => onDigitPressed('1')),
-                      ),
-                    );
-                  case _KeypadButton.digit2:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('2', () => onDigitPressed('2')),
-                      ),
-                    );
-                  case _KeypadButton.digit3:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('3', () => onDigitPressed('3')),
-                      ),
-                    );
-                  case _KeypadButton.digit4:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('4', () => onDigitPressed('4')),
-                      ),
-                    );
-                  case _KeypadButton.digit5:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('5', () => onDigitPressed('5')),
-                      ),
-                    );
-                  case _KeypadButton.digit6:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('6', () => onDigitPressed('6')),
-                      ),
-                    );
-                  case _KeypadButton.digit7:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('7', () => onDigitPressed('7')),
-                      ),
-                    );
-                  case _KeypadButton.digit8:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('8', () => onDigitPressed('8')),
-                      ),
-                    );
-                  case _KeypadButton.digit9:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('9', () => onDigitPressed('9')),
-                      ),
-                    );
-                  case _KeypadButton.decimal:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton(',', onDecimal),
-                      ),
-                    );
-                  case _KeypadButton.digit0:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('0', () => onDigitPressed('0')),
-                      ),
-                    );
-                  case _KeypadButton.backspace:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: ElevatedButton(
-                          onPressed: onBackspace,
-                          style: buttonStyle,
-                          child: const Icon(Icons.backspace_outlined),
-                        ),
-                      ),
-                    );
-                  case _KeypadButton.clear:
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: buildButton('Сброс', onClear),
-                      ),
-                    );
-                }
-              }).toList(),
-            ),
+        buildRow([
+          buildButton(
+            const Text('AC'),
+            onAllClear,
+            style: secondaryStyle,
           ),
+          buildButton(
+            const Icon(Icons.backspace_outlined),
+            onBackspace,
+            style: secondaryStyle,
+          ),
+          buildButton(
+            const Text('÷'),
+            () => onOperatorPressed('/'),
+            style: operatorStyle,
+          ),
+          buildButton(
+            const Text('×'),
+            () => onOperatorPressed('*'),
+            style: operatorStyle,
+          ),
+        ]),
+        buildRow([
+          buildButton(const Text('7'), () => onDigitPressed('7')),
+          buildButton(const Text('8'), () => onDigitPressed('8')),
+          buildButton(const Text('9'), () => onDigitPressed('9')),
+          buildButton(
+            const Text('−'),
+            () => onOperatorPressed('-'),
+            style: operatorStyle,
+          ),
+        ]),
+        buildRow([
+          buildButton(const Text('4'), () => onDigitPressed('4')),
+          buildButton(const Text('5'), () => onDigitPressed('5')),
+          buildButton(const Text('6'), () => onDigitPressed('6')),
+          buildButton(
+            const Text('+'),
+            () => onOperatorPressed('+'),
+            style: operatorStyle,
+          ),
+        ]),
+        buildRow([
+          buildButton(const Text('1'), () => onDigitPressed('1')),
+          buildButton(const Text('2'), () => onDigitPressed('2')),
+          buildButton(const Text('3'), () => onDigitPressed('3')),
+          buildButton(
+            const Text('='),
+            onEvaluate,
+            style: evaluateStyle,
+          ),
+        ]),
+        buildRow([
+          buildButton(
+            const Text('0'),
+            () => onDigitPressed('0'),
+            flex: 2,
+          ),
+          buildButton(const Text('.'), onDecimal),
+          buildSpacer(),
+        ]),
       ],
     );
   }
 }
-
-enum _KeypadButton {
-  digit1,
-  digit2,
-  digit3,
-  digit4,
-  digit5,
-  digit6,
-  digit7,
-  digit8,
-  digit9,
-  decimal,
-  digit0,
-  backspace,
-  clear,
-}
-
-const List<List<_KeypadButton>> _buttonRows = [
-  [_KeypadButton.digit1, _KeypadButton.digit2, _KeypadButton.digit3],
-  [_KeypadButton.digit4, _KeypadButton.digit5, _KeypadButton.digit6],
-  [_KeypadButton.digit7, _KeypadButton.digit8, _KeypadButton.digit9],
-  [_KeypadButton.decimal, _KeypadButton.digit0, _KeypadButton.backspace],
-  [_KeypadButton.clear],
-];

--- a/lib/ui/widgets/callout_card.dart
+++ b/lib/ui/widgets/callout_card.dart
@@ -8,6 +8,8 @@ class CalloutCard extends StatelessWidget {
     this.trailing,
     this.onTap,
     this.child,
+    this.borderless = false,
+    this.centered = false,
   });
 
   final String title;
@@ -15,39 +17,49 @@ class CalloutCard extends StatelessWidget {
   final Widget? trailing;
   final VoidCallback? onTap;
   final Widget? child;
+  final bool borderless;
+  final bool centered;
 
   @override
   Widget build(BuildContext context) {
-    final content = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    final textAlign = centered ? TextAlign.center : TextAlign.start;
+    final crossAxisAlignment =
+        centered ? CrossAxisAlignment.center : CrossAxisAlignment.start;
+    final headerContent = Column(
+      crossAxisAlignment: crossAxisAlignment,
       children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleMedium
-                        ?.copyWith(fontWeight: FontWeight.w600),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: 4),
-                    Text(
-                      subtitle!,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            if (trailing != null) trailing!,
-          ],
+        Text(
+          title,
+          textAlign: textAlign,
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(fontWeight: FontWeight.w600),
         ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 4),
+          Text(
+            subtitle!,
+            textAlign: textAlign,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ],
+    );
+
+    final content = Column(
+      crossAxisAlignment: crossAxisAlignment,
+      children: [
+        if (trailing != null)
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(child: headerContent),
+              trailing!,
+            ],
+          )
+        else
+          headerContent,
         if (child != null) ...[
           const SizedBox(height: 16),
           child!,
@@ -55,10 +67,19 @@ class CalloutCard extends StatelessWidget {
       ],
     );
 
+    final borderRadius = BorderRadius.circular(20);
+    final cardColor = borderless
+        ? Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.4)
+        : null;
+
     return Card(
+      elevation: borderless ? 0 : null,
+      color: cardColor,
+      shape: RoundedRectangleBorder(borderRadius: borderRadius),
+      surfaceTintColor: borderless ? Colors.transparent : null,
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(20),
           child: content,

--- a/lib/ui/widgets/period_selector.dart
+++ b/lib/ui/widgets/period_selector.dart
@@ -12,43 +12,37 @@ class PeriodSelector extends ConsumerWidget {
     final activePeriod = ref.watch(activePeriodProvider);
     final controller = ref.read(activePeriodProvider.notifier);
 
-    return Row(
-      children: [
-        Expanded(
-          child: DropdownButtonFormField<String>(
-            value: activePeriod.id,
-            borderRadius: BorderRadius.circular(16),
-            decoration: const InputDecoration(
-              labelText: 'Период бюджета',
-            ),
-            items: [
-              for (final period in periods)
-                DropdownMenuItem(
-                  value: period.id,
-                  child: Text(period.title),
-                ),
-              const DropdownMenuItem(
-                value: 'custom',
-                child: Text('Пользовательский'),
-              ),
-            ],
-            onChanged: (value) {
-              if (value == null) {
-                return;
-              }
-              if (value == 'custom') {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('TODO: Добавить выбор пользовательского периода'),
-                  ),
-                );
-              } else {
-                controller.setActive(value);
-              }
-            },
-          ),
+    final labels = ['1–15', '15–31'];
+    final segments = <ButtonSegment<String>>[];
+
+    for (var i = 0; i < periods.length && i < labels.length; i++) {
+      segments.add(
+        ButtonSegment(
+          value: periods[i].id,
+          label: Text(labels[i]),
         ),
-      ],
+      );
+    }
+
+    if (segments.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SegmentedButton<String>(
+      segments: segments,
+      selected: {activePeriod.id},
+      showSelectedIcon: false,
+      style: SegmentedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        visualDensity: VisualDensity.compact,
+        textStyle: Theme.of(context).textTheme.bodyMedium,
+      ),
+      onSelectionChanged: (selection) {
+        if (selection.isEmpty) {
+          return;
+        }
+        controller.setActive(selection.first);
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace the budget period dropdown with a compact two-option segmented selector
- add borderless/centered callout styling, rework the planned section into a vertical list, and center the FAB
- upgrade the amount entry flow to a calculator keypad with expression parsing and result preview

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cea664d15c8326bf578ca24a979cf5