### PR TITLE
Implement category management and update home FAB

### DIFF
--- a/lib/data/mock/mock_repositories.dart
+++ b/lib/data/mock/mock_repositories.dart
@@ -82,7 +82,7 @@ class AccountsRepository {
   List<Account> getAccounts() => List.unmodifiable(_accounts);
 }
 
-class CategoriesRepository {
+class CategoriesRepository extends ChangeNotifier {
   CategoriesRepository() {
     _categories = [
       Category(
@@ -128,9 +128,11 @@ class CategoriesRepository {
         icon: Icons.security,
       ),
     ];
+    _idCounter = _categories.length;
   }
 
   late final List<Category> _categories;
+  int _idCounter = 0;
 
   List<Category> getByType(OperationType type) {
     return _categories.where((category) => category.type == type).toList();
@@ -141,6 +143,58 @@ class CategoriesRepository {
       (category) => category.id == id,
       orElse: () => _categories.first,
     );
+  }
+
+  void addCategory({
+    required OperationType type,
+    required String name,
+  }) {
+    final category = Category(
+      id: 'cat-custom-${_idCounter++}',
+      name: name,
+      type: type,
+      icon: _defaultIconForType(type),
+    );
+    _categories.add(category);
+    notifyListeners();
+  }
+
+  void updateCategory(
+    String id, {
+    String? name,
+  }) {
+    final index = _categories.indexWhere((element) => element.id == id);
+    if (index == -1) {
+      return;
+    }
+    final current = _categories[index];
+    _categories[index] = Category(
+      id: current.id,
+      name: name ?? current.name,
+      type: current.type,
+      icon: current.icon,
+      subcategory: current.subcategory,
+    );
+    notifyListeners();
+  }
+
+  void removeCategory(String id) {
+    final initialLength = _categories.length;
+    _categories.removeWhere((category) => category.id == id);
+    if (_categories.length != initialLength) {
+      notifyListeners();
+    }
+  }
+
+  IconData _defaultIconForType(OperationType type) {
+    switch (type) {
+      case OperationType.income:
+        return Icons.trending_up;
+      case OperationType.expense:
+        return Icons.trending_down;
+      case OperationType.savings:
+        return Icons.savings;
+    }
   }
 }
 

--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../state/entry_flow_providers.dart';
 import '../ui/accounts/account_create_stub.dart';
 import '../ui/accounts/account_edit_stub.dart';
 import '../ui/accounts/accounts_list_stub.dart';
@@ -151,26 +150,8 @@ class ScaffoldWithNavigationShell extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final entryController = ref.read(entryFlowControllerProvider.notifier);
-    final isHomeTab = navigationShell.currentIndex == 0;
-
     return Scaffold(
       body: navigationShell,
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      floatingActionButton: isHomeTab
-          ? Semantics(
-              button: true,
-              label: 'Добавить операцию',
-              child: FloatingActionButton(
-                onPressed: () {
-                  entryController.startNew();
-                  context.pushNamed(RouteNames.entryAmount);
-                },
-                tooltip: 'Добавить операцию',
-                child: const Icon(Icons.add),
-              ),
-            )
-          : null,
       bottomNavigationBar: NavigationBar(
         selectedIndex: navigationShell.currentIndex,
         onDestinationSelected: (index) => _onItemTapped(context, index),

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -36,13 +36,16 @@ final accountsRepositoryProvider = Provider<AccountsRepository>((ref) {
   return AccountsRepository();
 });
 
-final categoriesRepositoryProvider = Provider<CategoriesRepository>((ref) {
+final categoriesRepositoryProvider =
+    ChangeNotifierProvider<CategoriesRepository>((ref) {
   return CategoriesRepository();
 });
 
 final operationsRepositoryProvider = Provider<OperationsRepository>((ref) {
   return OperationsRepository();
 });
+
+final isSheetOpenProvider = StateProvider<bool>((_) => false);
 
 final accountsProvider = Provider<List<Account>>((ref) {
   final repository = ref.watch(accountsRepositoryProvider);

--- a/lib/ui/categories/category_edit_form.dart
+++ b/lib/ui/categories/category_edit_form.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/mock/mock_models.dart';
+import '../../state/app_providers.dart';
+
+Future<void> showCategoryEditForm(
+  BuildContext context,
+  WidgetRef ref, {
+  required OperationType type,
+  Category? initial,
+}) async {
+  final formKey = GlobalKey<FormState>();
+  final controller = TextEditingController(text: initial?.name ?? '');
+
+  try {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      clipBehavior: Clip.antiAlias,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) {
+        final bottomInset = MediaQuery.of(sheetContext).viewInsets.bottom;
+        return Padding(
+          padding: EdgeInsets.only(
+            left: 24,
+            right: 24,
+            top: 24,
+            bottom: 16 + bottomInset,
+          ),
+          child: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Container(
+                    width: 36,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: Theme.of(sheetContext).colorScheme.outlineVariant,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  initial == null
+                      ? 'Новая категория'
+                      : 'Редактирование категории',
+                  style: Theme.of(sheetContext).textTheme.titleMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                TextFormField(
+                  controller: controller,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Название',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Укажите название';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.of(sheetContext).pop(),
+                      child: const Text('Отмена'),
+                    ),
+                    const Spacer(),
+                    FilledButton(
+                      onPressed: () {
+                        if (!formKey.currentState!.validate()) {
+                          return;
+                        }
+                        final name = controller.text.trim();
+                        final repository =
+                            ref.read(categoriesRepositoryProvider);
+                        if (initial == null) {
+                          repository.addCategory(type: type, name: name);
+                        } else {
+                          repository.updateCategory(initial.id, name: name);
+                        }
+                        Navigator.of(sheetContext).pop();
+                      },
+                      child: const Text('Сохранить'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  } finally {
+    controller.dispose();
+  }
+}

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../state/app_providers.dart';
+import '../../state/entry_flow_providers.dart';
 import '../../state/planned_providers.dart';
 import '../../utils/formatting.dart';
 import '../widgets/callout_card.dart';
@@ -20,98 +21,111 @@ class HomeScreen extends ConsumerWidget {
     final summary = ref.watch(periodSummaryProvider);
     final accounts = ref.watch(accountsProvider);
     final hasOperations = ref.watch(hasOperationsProvider);
+    final hideFab = ref.watch(isSheetOpenProvider);
+    final entryController = ref.read(entryFlowControllerProvider.notifier);
 
-    return SafeArea(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const PeriodSelector(),
-            const SizedBox(height: 16),
-            _buildRemainingSection(context, summary, hasOperations),
-            const SizedBox(height: 16),
-            CalloutCard(
-              title: 'Траты сегодня',
-              subtitle:
-                  '${formatCurrency(summary.todaySpent)} из ${formatCurrency(summary.todayBudget)}',
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => context.pushNamed(RouteNames.operations),
-              child: ProgressLine(
-                value: summary.dailyProgress,
-                label: 'Прогресс дня',
-              ),
+    return Scaffold(
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: hideFab
+          ? null
+          : _OvalFab(
+              onPressed: () {
+                entryController.startNew();
+                context.pushNamed(RouteNames.entryAmount);
+              },
             ),
-            const SizedBox(height: 16),
-            CalloutCard(
-              title: 'Запланировано',
-              subtitle: 'Быстрый доступ к будущим операциям',
-              child: _PlannedOverview(ref: ref),
-            ),
-            const SizedBox(height: 16),
-            CalloutCard(
-              title: 'Счета',
-              subtitle: 'Баланс ваших кошельков и карт',
-              trailing: IconButton(
-                onPressed: () => context.pushNamed(RouteNames.accountCreate),
-                icon: const Icon(Icons.add),
-                tooltip: 'Добавить счёт',
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const PeriodSelector(),
+              const SizedBox(height: 16),
+              _buildRemainingSection(context, summary, hasOperations),
+              const SizedBox(height: 16),
+              CalloutCard(
+                title: 'Траты сегодня',
+                subtitle:
+                    '${formatCurrency(summary.todaySpent)} из ${formatCurrency(summary.todayBudget)}',
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => context.pushNamed(RouteNames.operations),
+                child: ProgressLine(
+                  value: summary.dailyProgress,
+                  label: 'Прогресс дня',
+                ),
               ),
-              child: accounts.isEmpty
-                  ? const Text('Добавьте первый счёт, чтобы видеть баланс здесь.')
-                  : Column(
-                      children: [
-                        for (final account in accounts)
-                          ListTile(
-                            contentPadding: EdgeInsets.zero,
-                            leading: CircleAvatar(
-                              backgroundColor: account.color.withOpacity(0.15),
-                              child: Icon(
-                                Icons.account_balance_wallet,
-                                color: account.color,
+              const SizedBox(height: 16),
+              CalloutCard(
+                title: 'Запланировано',
+                subtitle: 'Быстрый доступ к будущим операциям',
+                child: _PlannedOverview(ref: ref),
+              ),
+              const SizedBox(height: 16),
+              CalloutCard(
+                title: 'Счета',
+                subtitle: 'Баланс ваших кошельков и карт',
+                trailing: IconButton(
+                  onPressed: () => context.pushNamed(RouteNames.accountCreate),
+                  icon: const Icon(Icons.add),
+                  tooltip: 'Добавить счёт',
+                ),
+                child: accounts.isEmpty
+                    ? const Text('Добавьте первый счёт, чтобы видеть баланс здесь.')
+                    : Column(
+                        children: [
+                          for (final account in accounts)
+                            ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              leading: CircleAvatar(
+                                backgroundColor: account.color.withOpacity(0.15),
+                                child: Icon(
+                                  Icons.account_balance_wallet,
+                                  color: account.color,
+                                ),
+                              ),
+                              title: Text(account.name),
+                              subtitle: Text(formatCurrency(account.balance)),
+                              trailing: const Icon(Icons.chevron_right),
+                              onTap: () => context.pushNamed(
+                                RouteNames.accountEdit,
+                                extra: account.name,
                               ),
                             ),
-                            title: Text(account.name),
-                            subtitle: Text(formatCurrency(account.balance)),
-                            trailing: const Icon(Icons.chevron_right),
-                            onTap: () => context.pushNamed(
-                              RouteNames.accountEdit,
-                              extra: account.name,
-                            ),
-                          ),
+                        ],
+                      ),
+              ),
+              const SizedBox(height: 32),
+              Text(
+                '${period.title}: операции',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              if (!hasOperations)
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Text(
+                          'Операций пока нет',
+                          style: TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        SizedBox(height: 8),
+                        Text('Нажмите на “+”, чтобы добавить первую запись.'),
                       ],
                     ),
-            ),
-            const SizedBox(height: 32),
-            Text(
-              '${period.title}: операции',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            if (!hasOperations)
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: const [
-                      Text(
-                        'Операций пока нет',
-                        style: TextStyle(fontWeight: FontWeight.w600),
-                      ),
-                      SizedBox(height: 8),
-                      Text('Нажмите на “+”, чтобы добавить первую запись.'),
-                    ],
                   ),
+                )
+              else
+                FilledButton.tonalIcon(
+                  onPressed: () => context.pushNamed(RouteNames.operations),
+                  icon: const Icon(Icons.receipt_long),
+                  label: const Text('Открыть операции периода'),
                 ),
-              )
-            else
-              FilledButton.tonalIcon(
-                onPressed: () => context.pushNamed(RouteNames.operations),
-                icon: const Icon(Icons.receipt_long),
-                label: const Text('Открыть операции периода'),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -242,6 +256,25 @@ class _RemainingInfoCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _OvalFab extends StatelessWidget {
+  const _OvalFab({
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton.extended(
+      onPressed: onPressed,
+      icon: const Icon(Icons.add),
+      label: const Text(''),
+      shape: const StadiumBorder(),
+      extendedPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 0),
     );
   }
 }

--- a/lib/ui/planned/planned_sheet.dart
+++ b/lib/ui/planned/planned_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../state/app_providers.dart';
 import '../../state/planned_providers.dart';
 import '../../utils/formatting.dart';
 import 'planned_add_form.dart';
@@ -10,6 +11,7 @@ Future<void> showPlannedSheet(
   WidgetRef ref, {
   required PlannedType type,
 }) {
+  ref.read(isSheetOpenProvider.notifier).state = true;
   return showModalBottomSheet(
     context: context,
     isScrollControlled: true,
@@ -207,7 +209,9 @@ Future<void> showPlannedSheet(
         ),
       );
     },
-  );
+  ).whenComplete(() {
+    ref.read(isSheetOpenProvider.notifier).state = false;
+  });
 }
 
 class _SheetHeader extends StatelessWidget {

--- a/lib/ui/settings/categories_manage_screen.dart
+++ b/lib/ui/settings/categories_manage_screen.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/mock/mock_models.dart';
+import '../../state/app_providers.dart';
+import '../categories/category_edit_form.dart';
+
+class CategoriesManageScreen extends ConsumerStatefulWidget {
+  const CategoriesManageScreen({super.key});
+
+  @override
+  ConsumerState<CategoriesManageScreen> createState() =>
+      _CategoriesManageScreenState();
+}
+
+class _CategoriesManageScreenState
+    extends ConsumerState<CategoriesManageScreen> {
+  OperationType _selectedType = OperationType.income;
+
+  @override
+  Widget build(BuildContext context) {
+    final repository = ref.watch(categoriesRepositoryProvider);
+    final categories = repository.getByType(_selectedType);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Настройка категорий'),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: FilledButton.icon(
+        onPressed: () => showCategoryEditForm(
+          context,
+          ref,
+          type: _selectedType,
+        ),
+        icon: const Icon(Icons.add),
+        label: const Text('Добавить'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 96),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SegmentedButton<OperationType>(
+              segments: const [
+                ButtonSegment(
+                  value: OperationType.income,
+                  label: Text('Доходы'),
+                  icon: Icon(Icons.trending_up),
+                ),
+                ButtonSegment(
+                  value: OperationType.expense,
+                  label: Text('Расходы'),
+                  icon: Icon(Icons.trending_down),
+                ),
+                ButtonSegment(
+                  value: OperationType.savings,
+                  label: Text('Сбережения'),
+                  icon: Icon(Icons.savings),
+                ),
+              ],
+              selected: {_selectedType},
+              onSelectionChanged: (value) {
+                setState(() => _selectedType = value.first);
+              },
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: categories.isEmpty
+                  ? Center(
+                      child: Text(
+                        'Категории не найдены',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    )
+                  : ListView.separated(
+                      itemCount: categories.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        final category = categories[index];
+                        return Card(
+                          child: ListTile(
+                            leading: CircleAvatar(
+                              backgroundColor:
+                                  category.type.color.withOpacity(0.15),
+                              child: Icon(
+                                category.icon,
+                                color: category.type.color,
+                              ),
+                            ),
+                            title: Text(category.name),
+                            subtitle: category.subcategory != null
+                                ? Text(category.subcategory!)
+                                : null,
+                            onTap: () => showCategoryEditForm(
+                              context,
+                              ref,
+                              type: category.type,
+                              initial: category,
+                            ),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  tooltip: 'Редактировать',
+                                  onPressed: () => showCategoryEditForm(
+                                    context,
+                                    ref,
+                                    type: category.type,
+                                    initial: category,
+                                  ),
+                                  icon: const Icon(Icons.edit_outlined),
+                                ),
+                                PopupMenuButton<_CategoryAction>(
+                                  onSelected: (action) {
+                                    if (action == _CategoryAction.delete) {
+                                      ref
+                                          .read(categoriesRepositoryProvider)
+                                          .removeCategory(category.id);
+                                    }
+                                  },
+                                  itemBuilder: (context) => const [
+                                    PopupMenuItem(
+                                      value: _CategoryAction.delete,
+                                      child: Text('Удалить'),
+                                    ),
+                                  ],
+                                  icon: const Icon(Icons.more_vert),
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum _CategoryAction { delete }

--- a/lib/ui/settings/settings_placeholder.dart
+++ b/lib/ui/settings/settings_placeholder.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../state/app_providers.dart';
-import 'categories_settings_stub.dart';
+import 'categories_manage_screen.dart';
 import 'necessity_settings_stub.dart';
 
 class SettingsPlaceholder extends ConsumerStatefulWidget {
@@ -144,7 +144,7 @@ class _SettingsPlaceholderState extends ConsumerState<SettingsPlaceholder> {
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (_) => const CategoriesSettingsStub(),
+                        builder: (_) => const CategoriesManageScreen(),
                       ),
                     );
                   },


### PR DESCRIPTION
## Summary
- extend the categories repository with CRUD methods and expose it as a ChangeNotifier for updates
- add a reusable bottom sheet form and a categories management screen that mirrors the selection UI with editing
- hide and restyle the home FAB while planned sheets are open and update navigation/settings wiring

## Testing
- `flutter analyze` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec5ee59b48326901272338e5a81b0