### PR TITLE
Fix categories repository provider type

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -37,7 +37,7 @@ final accountsRepositoryProvider = Provider<AccountsRepository>((ref) {
 });
 
 final categoriesRepositoryProvider =
-    ChangeNotifierProvider<CategoriesRepository>((ref) {
+    Provider<CategoriesRepository>((ref) {
   return CategoriesRepository();
 });
 


### PR DESCRIPTION
## Summary
- switch the categories repository provider to use a basic Provider instead of ChangeNotifierProvider

## Testing
- flutter test *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ceca6203f48326bb4413cb3b9ff635