### PR TITLE
Implement grouped categories and centered FAB

### DIFF
--- a/lib/data/mock/mock_models.dart
+++ b/lib/data/mock/mock_models.dart
@@ -6,6 +6,8 @@ enum OperationType {
   savings,
 }
 
+typedef CategoryType = OperationType;
+
 extension OperationTypeX on OperationType {
   String get label {
     switch (this) {
@@ -68,17 +70,19 @@ class Account {
 class Category {
   Category({
     required this.id,
-    required this.name,
     required this.type,
+    required this.name,
     required this.icon,
-    this.subcategory,
+    this.parentId,
+    required this.isGroup,
   });
 
   final String id;
+  final CategoryType type;
   final String name;
-  final OperationType type;
   final IconData icon;
-  final String? subcategory;
+  final String? parentId;
+  final bool isGroup;
 }
 
 class Operation {

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -37,7 +37,7 @@ final accountsRepositoryProvider = Provider<AccountsRepository>((ref) {
 });
 
 final categoriesRepositoryProvider =
-    Provider<CategoriesRepository>((ref) {
+    ChangeNotifierProvider<CategoriesRepository>((ref) {
   return CategoriesRepository();
 });
 

--- a/lib/ui/categories/category_actions.dart
+++ b/lib/ui/categories/category_actions.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+enum AddCategoryOption { group, category }
+
+enum CategoryAction { rename, delete }
+
+Future<AddCategoryOption?> showAddCategoryOptions(BuildContext context) {
+  return showModalBottomSheet<AddCategoryOption>(
+    context: context,
+    builder: (sheetContext) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.folder),
+              title: const Text('Папка (группа)'),
+              onTap: () =>
+                  Navigator.of(sheetContext).pop(AddCategoryOption.group),
+            ),
+            ListTile(
+              leading: const Icon(Icons.label),
+              title: const Text('Категория'),
+              onTap: () =>
+                  Navigator.of(sheetContext).pop(AddCategoryOption.category),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+Future<CategoryAction?> showCategoryActions(
+  BuildContext context, {
+  required bool isGroup,
+}) {
+  return showModalBottomSheet<CategoryAction>(
+    context: context,
+    builder: (sheetContext) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.edit),
+              title: Text(isGroup ? 'Переименовать папку' : 'Переименовать категорию'),
+              onTap: () =>
+                  Navigator.of(sheetContext).pop(CategoryAction.rename),
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text('Удалить'),
+              onTap: () =>
+                  Navigator.of(sheetContext).pop(CategoryAction.delete),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/ui/categories/category_tree_view.dart
+++ b/lib/ui/categories/category_tree_view.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+
+import '../../data/mock/mock_models.dart';
+
+typedef CategoryCallback = void Function(Category category);
+
+class CategoryTreeView extends StatelessWidget {
+  const CategoryTreeView({
+    super.key,
+    required this.groups,
+    required this.childrenByGroup,
+    required this.ungrouped,
+    this.onCategoryTap,
+    this.onCategoryLongPress,
+    this.onGroupTap,
+    this.onGroupLongPress,
+  });
+
+  final List<Category> groups;
+  final Map<String, List<Category>> childrenByGroup;
+  final List<Category> ungrouped;
+  final CategoryCallback? onCategoryTap;
+  final CategoryCallback? onCategoryLongPress;
+  final CategoryCallback? onGroupTap;
+  final CategoryCallback? onGroupLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    if (groups.isEmpty && ungrouped.isEmpty) {
+      return Center(
+        child: Text(
+          'Категории не найдены',
+          style: Theme.of(context).textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+
+    final items = <Widget>[];
+
+    for (final group in groups) {
+      items.add(_GroupCard(
+        key: ValueKey(group.id),
+        group: group,
+        children: childrenByGroup[group.id] ?? const <Category>[],
+        onCategoryTap: onCategoryTap,
+        onCategoryLongPress: onCategoryLongPress,
+        onGroupTap: onGroupTap,
+        onGroupLongPress: onGroupLongPress,
+      ));
+      items.add(const SizedBox(height: 12));
+    }
+
+    if (ungrouped.isNotEmpty) {
+      if (groups.isNotEmpty) {
+        items.add(Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Text(
+            'Без папки',
+            style: Theme.of(context)
+                .textTheme
+                .labelLarge
+                ?.copyWith(color: Theme.of(context).colorScheme.outline),
+          ),
+        ));
+      }
+      for (final category in ungrouped) {
+        items.add(_CategoryCard(
+          category: category,
+          onTap: onCategoryTap,
+          onLongPress: onCategoryLongPress,
+        ));
+        items.add(const SizedBox(height: 12));
+      }
+    }
+
+    if (items.isNotEmpty) {
+      items.removeLast();
+    }
+
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: items,
+    );
+  }
+}
+class _GroupCard extends StatefulWidget {
+  const _GroupCard({
+    super.key,
+    required this.group,
+    required this.children,
+    this.onCategoryTap,
+    this.onCategoryLongPress,
+    this.onGroupTap,
+    this.onGroupLongPress,
+  });
+
+  final Category group;
+  final List<Category> children;
+  final CategoryCallback? onCategoryTap;
+  final CategoryCallback? onCategoryLongPress;
+  final CategoryCallback? onGroupTap;
+  final CategoryCallback? onGroupLongPress;
+
+  @override
+  State<_GroupCard> createState() => _GroupCardState();
+}
+
+class _GroupCardState extends State<_GroupCard> {
+  bool _expanded = false;
+
+  void _toggleExpansion() {
+    if (widget.children.isEmpty) {
+      return;
+    }
+    setState(() {
+      _expanded = !_expanded;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = widget.group.type.color;
+    final hasChildren = widget.children.isNotEmpty;
+
+    return Card(
+      child: Column(
+        children: [
+          ListTile(
+            leading: CircleAvatar(
+              backgroundColor: color.withOpacity(0.15),
+              child: Icon(Icons.folder, color: color),
+            ),
+            title: Text(widget.group.name),
+            onTap: widget.onGroupTap ?? (hasChildren ? _toggleExpansion : null),
+            onLongPress: widget.onGroupLongPress != null
+                ? () => widget.onGroupLongPress!(widget.group)
+                : null,
+            trailing: hasChildren
+                ? IconButton(
+                    icon: Icon(
+                      _expanded ? Icons.expand_less : Icons.expand_more,
+                    ),
+                    onPressed: _toggleExpansion,
+                  )
+                : null,
+          ),
+          if (_expanded && hasChildren)
+            ...widget.children.map(
+              (category) => _CategoryTile(
+                category: category,
+                onTap: widget.onCategoryTap,
+                onLongPress: widget.onCategoryLongPress,
+                contentPadding: const EdgeInsets.fromLTRB(24, 0, 16, 0),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CategoryTile extends StatelessWidget {
+  const _CategoryTile({
+    required this.category,
+    this.onTap,
+    this.onLongPress,
+    this.contentPadding,
+  });
+
+  final Category category;
+  final CategoryCallback? onTap;
+  final CategoryCallback? onLongPress;
+  final EdgeInsetsGeometry? contentPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = category.type.color;
+    return ListTile(
+      contentPadding: contentPadding,
+      leading: CircleAvatar(
+        backgroundColor: color.withOpacity(0.15),
+        child: Icon(Icons.label, color: color),
+      ),
+      title: Text(category.name),
+      onTap: onTap != null ? () => onTap!(category) : null,
+      onLongPress: onLongPress != null ? () => onLongPress!(category) : null,
+    );
+  }
+}
+
+class _CategoryCard extends StatelessWidget {
+  const _CategoryCard({
+    required this.category,
+    this.onTap,
+    this.onLongPress,
+  });
+
+  final Category category;
+  final CategoryCallback? onTap;
+  final CategoryCallback? onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: _CategoryTile(
+        category: category,
+        onTap: onTap,
+        onLongPress: onLongPress,
+      ),
+    );
+  }
+}

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -269,12 +269,14 @@ class _OvalFab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FloatingActionButton.extended(
+    final theme = Theme.of(context);
+    return RawMaterialButton(
       onPressed: onPressed,
-      icon: const Icon(Icons.add),
-      label: const Text(''),
+      fillColor: theme.colorScheme.primary,
+      constraints: const BoxConstraints(minWidth: 72, minHeight: 56),
       shape: const StadiumBorder(),
-      extendedPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 0),
+      elevation: 6,
+      child: Icon(Icons.add, color: theme.colorScheme.onPrimary),
     );
   }
 }


### PR DESCRIPTION
## Summary
- center the home screen oval FAB icon with a custom RawMaterialButton implementation
- extend category data and repository to support groups, tree defaults, and CRUD helpers backed by a new shared tree view
- refresh category selection and management UIs with add/edit sheets, action menus, and controller-safe forms without persistent text controllers

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced05ff95483269ce0afe636cf6977