### PR TITLE
Add SQLite infrastructure and schema

### DIFF
--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -1,0 +1,49 @@
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+
+import 'migrations.dart';
+
+/// Provides access to the application database.
+class AppDatabase {
+  AppDatabase._();
+
+  static final AppDatabase instance = AppDatabase._();
+
+  Database? _database;
+
+  /// Lazily opens the database and returns an instance of [Database].
+  Future<Database> get database async {
+    final existingDatabase = _database;
+    if (existingDatabase != null && existingDatabase.isOpen) {
+      return existingDatabase;
+    }
+
+    _database = await _openDatabase();
+    return _database!;
+  }
+
+  /// Closes the database if it has been opened previously.
+  Future<void> close() async {
+    final db = _database;
+    if (db != null && db.isOpen) {
+      await db.close();
+      _database = null;
+    }
+  }
+
+  Future<Database> _openDatabase() async {
+    final dbPath = await getDatabasesPath();
+    final path = p.join(dbPath, 'finance_app.db');
+
+    return openDatabase(
+      path,
+      version: AppMigrations.latestVersion,
+      onCreate: (db, version) async {
+        await AppMigrations.runMigrations(db, 0, version);
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        await AppMigrations.runMigrations(db, oldVersion, newVersion);
+      },
+    );
+  }
+}

--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -1,0 +1,74 @@
+import 'package:sqflite/sqflite.dart';
+
+/// Defines all database migrations for the application.
+class AppMigrations {
+  AppMigrations._();
+
+  /// Latest schema version supported by the application.
+  static const int latestVersion = 1;
+
+  static final Map<int, List<String>> _migrationScripts = {
+    1: [
+      'CREATE TABLE accounts ('
+          'id INTEGER PRIMARY KEY, '
+          'name TEXT, '
+          'currency TEXT, '
+          'start_balance_minor INTEGER NOT NULL DEFAULT 0, '
+          'is_archived INTEGER NOT NULL DEFAULT 0'
+          ')',
+      'CREATE TABLE categories ('
+          'id INTEGER PRIMARY KEY, '
+          "type TEXT CHECK(type IN ('income','expense','saving')), "
+          'name TEXT, '
+          'is_group INTEGER NOT NULL DEFAULT 0, '
+          'parent_id INTEGER NULL, '
+          'archived INTEGER NOT NULL DEFAULT 0'
+          ')',
+      'CREATE TABLE transactions ('
+          'id INTEGER PRIMARY KEY, '
+          'account_id INTEGER NOT NULL, '
+          'category_id INTEGER NOT NULL, '
+          "type TEXT CHECK(type IN ('income','expense','saving')), "
+          'amount_minor INTEGER NOT NULL, '
+          'date TEXT NOT NULL, '
+          'time TEXT NULL, '
+          'note TEXT NULL, '
+          'is_planned INTEGER NOT NULL DEFAULT 0, '
+          'included_in_period INTEGER NOT NULL DEFAULT 1, '
+          'tags TEXT NULL'
+          ')',
+      'CREATE INDEX idx_transactions_date ON transactions(date)',
+      'CREATE INDEX idx_transactions_category_id ON transactions(category_id)',
+      'CREATE INDEX idx_transactions_account_id ON transactions(account_id)',
+      'CREATE INDEX idx_transactions_type ON transactions(type)',
+      'CREATE TABLE payouts ('
+          'id INTEGER PRIMARY KEY, '
+          "type TEXT CHECK(type IN ('advance','salary')), "
+          'date TEXT NOT NULL, '
+          'amount_minor INTEGER NOT NULL, '
+          'account_id INTEGER NOT NULL'
+          ')',
+      'CREATE TABLE settings ('
+          'key TEXT PRIMARY KEY, '
+          'value TEXT NOT NULL'
+          ')',
+    ],
+  };
+
+  /// Applies migrations from [oldVersion] (exclusive) up to [newVersion] (inclusive).
+  static Future<void> runMigrations(
+    Database db,
+    int oldVersion,
+    int newVersion,
+  ) async {
+    for (var version = oldVersion + 1; version <= newVersion; version++) {
+      final statements = _migrationScripts[version];
+      if (statements == null) {
+        continue;
+      }
+      for (final statement in statements) {
+        await db.execute(statement);
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   intl: ^0.20.2
   flutter_riverpod: ^2.5.1
   go_router: ^14.2.0
+  sqflite: ^2.3.3+1
+  path: ^1.9.0
 
   cupertino_icons: ^1.0.8
 


### PR DESCRIPTION
## Summary
- add sqflite and path dependencies for database access
- implement database singleton with migration runner
- define initial schema migration for accounts, categories, transactions, payouts, and settings tables

## Testing
- flutter pub get *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8b99db088326af9412a9620dd088