### PR TITLE
Implement SQLite repositories

### DIFF
--- a/lib/data/models/account.dart
+++ b/lib/data/models/account.dart
@@ -1,0 +1,51 @@
+class Account {
+  const Account({
+    this.id,
+    required this.name,
+    required this.currency,
+    required this.startBalanceMinor,
+    this.isArchived = false,
+  });
+
+  final int? id;
+  final String name;
+  final String currency;
+  final int startBalanceMinor;
+  final bool isArchived;
+
+  Account copyWith({
+    int? id,
+    String? name,
+    String? currency,
+    int? startBalanceMinor,
+    bool? isArchived,
+  }) {
+    return Account(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      currency: currency ?? this.currency,
+      startBalanceMinor: startBalanceMinor ?? this.startBalanceMinor,
+      isArchived: isArchived ?? this.isArchived,
+    );
+  }
+
+  factory Account.fromMap(Map<String, Object?> map) {
+    return Account(
+      id: map['id'] as int?,
+      name: map['name'] as String? ?? '',
+      currency: map['currency'] as String? ?? '',
+      startBalanceMinor: map['start_balance_minor'] as int? ?? 0,
+      isArchived: (map['is_archived'] as int? ?? 0) != 0,
+    );
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'currency': currency,
+      'start_balance_minor': startBalanceMinor,
+      'is_archived': isArchived ? 1 : 0,
+    };
+  }
+}

--- a/lib/data/models/category.dart
+++ b/lib/data/models/category.dart
@@ -1,0 +1,83 @@
+enum CategoryType { income, expense, saving }
+
+class Category {
+  const Category({
+    this.id,
+    required this.type,
+    required this.name,
+    this.isGroup = false,
+    this.parentId,
+    this.isArchived = false,
+  });
+
+  final int? id;
+  final CategoryType type;
+  final String name;
+  final bool isGroup;
+  final int? parentId;
+  final bool isArchived;
+
+  Category copyWith({
+    int? id,
+    CategoryType? type,
+    String? name,
+    bool? isGroup,
+    int? parentId,
+    bool? isArchived,
+  }) {
+    return Category(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      name: name ?? this.name,
+      isGroup: isGroup ?? this.isGroup,
+      parentId: parentId ?? this.parentId,
+      isArchived: isArchived ?? this.isArchived,
+    );
+  }
+
+  factory Category.fromMap(Map<String, Object?> map) {
+    return Category(
+      id: map['id'] as int?,
+      type: _typeFromString(map['type'] as String?),
+      name: map['name'] as String? ?? '',
+      isGroup: (map['is_group'] as int? ?? 0) != 0,
+      parentId: map['parent_id'] as int?,
+      isArchived: (map['archived'] as int? ?? 0) != 0,
+    );
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'id': id,
+      'type': _typeToString(type),
+      'name': name,
+      'is_group': isGroup ? 1 : 0,
+      'parent_id': parentId,
+      'archived': isArchived ? 1 : 0,
+    };
+  }
+
+  static CategoryType _typeFromString(String? raw) {
+    switch (raw) {
+      case 'income':
+        return CategoryType.income;
+      case 'expense':
+        return CategoryType.expense;
+      case 'saving':
+        return CategoryType.saving;
+      default:
+        throw ArgumentError.value(raw, 'raw', 'Unknown category type');
+    }
+  }
+
+  static String _typeToString(CategoryType type) {
+    switch (type) {
+      case CategoryType.income:
+        return 'income';
+      case CategoryType.expense:
+        return 'expense';
+      case CategoryType.saving:
+        return 'saving';
+    }
+  }
+}

--- a/lib/data/models/models.dart
+++ b/lib/data/models/models.dart
@@ -1,0 +1,4 @@
+export 'account.dart';
+export 'category.dart';
+export 'payout.dart';
+export 'transaction_record.dart';

--- a/lib/data/models/payout.dart
+++ b/lib/data/models/payout.dart
@@ -1,0 +1,87 @@
+enum PayoutType { advance, salary }
+
+class Payout {
+  const Payout({
+    this.id,
+    required this.type,
+    required this.date,
+    required this.amountMinor,
+    this.accountId,
+  });
+
+  final int? id;
+  final PayoutType type;
+  final DateTime date;
+  final int amountMinor;
+  final int? accountId;
+
+  Payout copyWith({
+    int? id,
+    PayoutType? type,
+    DateTime? date,
+    int? amountMinor,
+    int? accountId,
+  }) {
+    return Payout(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      date: date ?? this.date,
+      amountMinor: amountMinor ?? this.amountMinor,
+      accountId: accountId ?? this.accountId,
+    );
+  }
+
+  factory Payout.fromMap(Map<String, Object?> map) {
+    return Payout(
+      id: map['id'] as int?,
+      type: _typeFromString(map['type'] as String?),
+      date: _parseDate(map['date'] as String?),
+      amountMinor: map['amount_minor'] as int? ?? 0,
+      accountId: map['account_id'] as int?,
+    );
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'id': id,
+      'type': _typeToString(type),
+      'date': _formatDate(date),
+      'amount_minor': amountMinor,
+      'account_id': accountId,
+    };
+  }
+
+  static PayoutType _typeFromString(String? raw) {
+    switch (raw) {
+      case 'advance':
+        return PayoutType.advance;
+      case 'salary':
+        return PayoutType.salary;
+      default:
+        throw ArgumentError.value(raw, 'raw', 'Unknown payout type');
+    }
+  }
+
+  static String _typeToString(PayoutType type) {
+    switch (type) {
+      case PayoutType.advance:
+        return 'advance';
+      case PayoutType.salary:
+        return 'salary';
+    }
+  }
+
+  static DateTime _parseDate(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      final now = DateTime.now();
+      return DateTime(now.year, now.month, now.day);
+    }
+    return DateTime.parse(raw);
+  }
+
+  static String _formatDate(DateTime date) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '${date.year.toString().padLeft(4, '0')}-$month-$day';
+  }
+}

--- a/lib/data/models/transaction_record.dart
+++ b/lib/data/models/transaction_record.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+enum TransactionType { income, expense, saving }
+
+class TransactionRecord {
+  const TransactionRecord({
+    this.id,
+    required this.accountId,
+    required this.categoryId,
+    required this.type,
+    required this.amountMinor,
+    required this.date,
+    this.time,
+    this.note,
+    this.isPlanned = false,
+    this.includedInPeriod = true,
+    this.tags = const <String>[],
+  });
+
+  final int? id;
+  final int accountId;
+  final int categoryId;
+  final TransactionType type;
+  final int amountMinor;
+  final DateTime date;
+  final String? time;
+  final String? note;
+  final bool isPlanned;
+  final bool includedInPeriod;
+  final List<String> tags;
+
+  TransactionRecord copyWith({
+    int? id,
+    int? accountId,
+    int? categoryId,
+    TransactionType? type,
+    int? amountMinor,
+    DateTime? date,
+    String? time,
+    String? note,
+    bool? isPlanned,
+    bool? includedInPeriod,
+    List<String>? tags,
+  }) {
+    return TransactionRecord(
+      id: id ?? this.id,
+      accountId: accountId ?? this.accountId,
+      categoryId: categoryId ?? this.categoryId,
+      type: type ?? this.type,
+      amountMinor: amountMinor ?? this.amountMinor,
+      date: date ?? this.date,
+      time: time ?? this.time,
+      note: note ?? this.note,
+      isPlanned: isPlanned ?? this.isPlanned,
+      includedInPeriod: includedInPeriod ?? this.includedInPeriod,
+      tags: tags ?? this.tags,
+    );
+  }
+
+  factory TransactionRecord.fromMap(Map<String, Object?> map) {
+    return TransactionRecord(
+      id: map['id'] as int?,
+      accountId: map['account_id'] as int? ?? 0,
+      categoryId: map['category_id'] as int? ?? 0,
+      type: _typeFromString(map['type'] as String?),
+      amountMinor: map['amount_minor'] as int? ?? 0,
+      date: _parseDate(map['date'] as String?),
+      time: map['time'] as String?,
+      note: map['note'] as String?,
+      isPlanned: (map['is_planned'] as int? ?? 0) != 0,
+      includedInPeriod: (map['included_in_period'] as int? ?? 0) != 0,
+      tags: _decodeTags(map['tags'] as String?),
+    );
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'id': id,
+      'account_id': accountId,
+      'category_id': categoryId,
+      'type': _typeToString(type),
+      'amount_minor': amountMinor,
+      'date': _formatDate(date),
+      'time': time,
+      'note': note,
+      'is_planned': isPlanned ? 1 : 0,
+      'included_in_period': includedInPeriod ? 1 : 0,
+      'tags': tags.isEmpty ? null : jsonEncode(tags),
+    };
+  }
+
+  static TransactionType _typeFromString(String? raw) {
+    switch (raw) {
+      case 'income':
+        return TransactionType.income;
+      case 'expense':
+        return TransactionType.expense;
+      case 'saving':
+        return TransactionType.saving;
+      default:
+        throw ArgumentError.value(raw, 'raw', 'Unknown transaction type');
+    }
+  }
+
+  static String _typeToString(TransactionType type) {
+    switch (type) {
+      case TransactionType.income:
+        return 'income';
+      case TransactionType.expense:
+        return 'expense';
+      case TransactionType.saving:
+        return 'saving';
+    }
+  }
+
+  static String _formatDate(DateTime date) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '${date.year.toString().padLeft(4, '0')}-$month-$day';
+  }
+
+  static DateTime _parseDate(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      final now = DateTime.now();
+      return DateTime(now.year, now.month, now.day);
+    }
+    return DateTime.parse(raw);
+  }
+
+  static List<String> _decodeTags(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return const [];
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is List) {
+        return decoded.whereType<String>().toList();
+      }
+      return const [];
+    } catch (_) {
+      return const [];
+    }
+  }
+}

--- a/lib/data/repositories/accounts_repository.dart
+++ b/lib/data/repositories/accounts_repository.dart
@@ -1,0 +1,140 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+import '../models/account.dart';
+
+abstract class AccountsRepository {
+  Future<List<Account>> getAll();
+
+  Future<Account?> getById(int id);
+
+  Future<int> create(Account account);
+
+  Future<void> update(Account account);
+
+  Future<void> delete(int id);
+
+  Future<int> getComputedBalanceMinor(int accountId);
+
+  Future<void> reconcileToComputed(int accountId);
+}
+
+class SqliteAccountsRepository implements AccountsRepository {
+  SqliteAccountsRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  static const String savingsAccountName = 'Сберегательный';
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<int> create(Account account) async {
+    final db = await _db;
+    final values = account.toMap()..remove('id');
+    return db.insert('accounts', values);
+  }
+
+  @override
+  Future<void> delete(int id) async {
+    final db = await _db;
+    await db.delete('accounts', where: 'id = ?', whereArgs: [id]);
+  }
+
+  @override
+  Future<List<Account>> getAll() async {
+    final db = await _db;
+    final rows = await db.query('accounts', orderBy: 'name');
+    return rows.map(Account.fromMap).toList();
+  }
+
+  @override
+  Future<Account?> getById(int id) async {
+    final db = await _db;
+    final rows = await db.query(
+      'accounts',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return Account.fromMap(rows.first);
+  }
+
+  @override
+  Future<int> getComputedBalanceMinor(int accountId) async {
+    final db = await _db;
+    final accountRow = await db.query(
+      'accounts',
+      columns: ['start_balance_minor', 'name'],
+      where: 'id = ?',
+      whereArgs: [accountId],
+      limit: 1,
+    );
+    if (accountRow.isEmpty) {
+      throw ArgumentError.value(accountId, 'accountId', 'Account not found');
+    }
+    final startBalance = (accountRow.first['start_balance_minor'] as int?) ?? 0;
+    final name = accountRow.first['name'] as String? ?? '';
+    final isSavingsAccount =
+        name.trim().toLowerCase() == savingsAccountName.toLowerCase();
+
+    final result = await db.rawQuery(
+      '''
+      SELECT
+        COALESCE(SUM(CASE WHEN type = 'income' THEN amount_minor END), 0) AS income_sum,
+        COALESCE(SUM(CASE WHEN type = 'expense' THEN amount_minor END), 0) AS expense_sum,
+        COALESCE(SUM(CASE WHEN type = 'saving' THEN amount_minor END), 0) AS saving_sum
+      FROM transactions
+      WHERE account_id = ? AND is_planned = 0 AND included_in_period = 1
+      ''',
+      [accountId],
+    );
+    final row = result.first;
+    final incomeSum = _readInt(row['income_sum']);
+    final expenseSum = _readInt(row['expense_sum']);
+    final savingSum = _readInt(row['saving_sum']);
+
+    final incomingSaving = isSavingsAccount ? savingSum : 0;
+    final outgoingSaving = isSavingsAccount ? 0 : savingSum;
+
+    return startBalance + incomeSum - expenseSum + incomingSaving - outgoingSaving;
+  }
+
+  @override
+  Future<void> reconcileToComputed(int accountId) async {
+    final computed = await getComputedBalanceMinor(accountId);
+    final db = await _db;
+    await db.update(
+      'accounts',
+      {'start_balance_minor': computed},
+      where: 'id = ?',
+      whereArgs: [accountId],
+    );
+  }
+
+  @override
+  Future<void> update(Account account) async {
+    final id = account.id;
+    if (id == null) {
+      throw ArgumentError('Account id is required for update');
+    }
+    final db = await _db;
+    await db.update(
+      'accounts',
+      account.toMap(),
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  int _readInt(Object? value) {
+    if (value is num) {
+      return value.toInt();
+    }
+    return 0;
+  }
+}

--- a/lib/data/repositories/categories_repository.dart
+++ b/lib/data/repositories/categories_repository.dart
@@ -1,0 +1,293 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+import '../models/category.dart';
+
+abstract class CategoriesRepository {
+  Future<List<Category>> getAll();
+
+  Future<Category?> getById(int id);
+
+  Future<List<Category>> getByType(CategoryType type);
+
+  Future<int> create(Category category);
+
+  Future<void> update(Category category);
+
+  Future<void> delete(int id);
+
+  Future<List<Category>> groupsByType(CategoryType type);
+
+  Future<List<Category>> childrenOf(int groupId);
+
+  Future<void> restoreDefaults();
+}
+
+class SqliteCategoriesRepository implements CategoriesRepository {
+  SqliteCategoriesRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<int> create(Category category) async {
+    final db = await _db;
+    final values = category.toMap()..remove('id');
+    return db.insert('categories', values);
+  }
+
+  @override
+  Future<void> delete(int id) async {
+    final db = await _db;
+    await db.delete('categories', where: 'id = ?', whereArgs: [id]);
+    await db.update(
+      'categories',
+      {'parent_id': null},
+      where: 'parent_id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  @override
+  Future<List<Category>> getAll() async {
+    final db = await _db;
+    final rows = await db.query('categories', orderBy: 'name');
+    return rows.map(Category.fromMap).toList();
+  }
+
+  @override
+  Future<Category?> getById(int id) async {
+    final db = await _db;
+    final rows = await db.query(
+      'categories',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return Category.fromMap(rows.first);
+  }
+
+  @override
+  Future<List<Category>> getByType(CategoryType type) async {
+    final db = await _db;
+    final rows = await db.query(
+      'categories',
+      where: 'type = ? AND is_group = 0',
+      whereArgs: [_typeToString(type)],
+      orderBy: 'name',
+    );
+    return rows.map(Category.fromMap).toList();
+  }
+
+  @override
+  Future<List<Category>> groupsByType(CategoryType type) async {
+    final db = await _db;
+    final rows = await db.query(
+      'categories',
+      where: 'type = ? AND is_group = 1',
+      whereArgs: [_typeToString(type)],
+      orderBy: 'name',
+    );
+    return rows.map(Category.fromMap).toList();
+  }
+
+  @override
+  Future<List<Category>> childrenOf(int groupId) async {
+    final db = await _db;
+    final rows = await db.query(
+      'categories',
+      where: 'parent_id = ? AND is_group = 0',
+      whereArgs: [groupId],
+      orderBy: 'name',
+    );
+    return rows.map(Category.fromMap).toList();
+  }
+
+  @override
+  Future<void> restoreDefaults() async {
+    final db = await _db;
+    await db.transaction((txn) async {
+      final defaultGroups = _defaultGroups();
+      for (final group in defaultGroups) {
+        final groupId = await _ensureCategory(
+          txn,
+          type: group.type,
+          name: group.name,
+          isGroup: true,
+        );
+        for (final child in group.children) {
+          await _ensureCategory(
+            txn,
+            type: group.type,
+            name: child,
+            parentId: groupId,
+          );
+        }
+      }
+
+      for (final entry in _defaultStandalone()) {
+        await _ensureCategory(
+          txn,
+          type: entry.type,
+          name: entry.name,
+        );
+      }
+    });
+  }
+
+  @override
+  Future<void> update(Category category) async {
+    final id = category.id;
+    if (id == null) {
+      throw ArgumentError('Category id is required for update');
+    }
+    final db = await _db;
+    await db.update(
+      'categories',
+      category.toMap(),
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<int> _ensureCategory(
+    DatabaseExecutor executor, {
+    required CategoryType type,
+    required String name,
+    bool isGroup = false,
+    int? parentId,
+  }) async {
+    final whereBuffer = StringBuffer('type = ? AND name = ?');
+    final args = <Object?>[_typeToString(type), name];
+    if (parentId == null) {
+      whereBuffer.write(' AND parent_id IS NULL');
+    } else {
+      whereBuffer.write(' AND parent_id = ?');
+      args.add(parentId);
+    }
+    whereBuffer.write(' AND is_group = ?');
+    args.add(isGroup ? 1 : 0);
+
+    final existing = await executor.query(
+      'categories',
+      columns: ['id'],
+      where: whereBuffer.toString(),
+      whereArgs: args,
+      limit: 1,
+    );
+    if (existing.isNotEmpty) {
+      return existing.first['id'] as int;
+    }
+
+    final values = <String, Object?>{
+      'type': _typeToString(type),
+      'name': name,
+      'is_group': isGroup ? 1 : 0,
+      'parent_id': parentId,
+      'archived': 0,
+    };
+    return executor.insert('categories', values);
+  }
+
+  String _typeToString(CategoryType type) {
+    switch (type) {
+      case CategoryType.income:
+        return 'income';
+      case CategoryType.expense:
+        return 'expense';
+      case CategoryType.saving:
+        return 'saving';
+    }
+  }
+}
+
+class _DefaultCategoryGroup {
+  const _DefaultCategoryGroup(
+    this.type,
+    this.name,
+    this.children,
+  );
+
+  final CategoryType type;
+  final String name;
+  final List<String> children;
+}
+
+class _DefaultCategoryEntry {
+  const _DefaultCategoryEntry(this.type, this.name);
+
+  final CategoryType type;
+  final String name;
+}
+
+List<_DefaultCategoryGroup> _defaultGroups() {
+  return const [
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Еда',
+      ['Магазины', 'Рестораны', 'Кафе', 'Доставка', 'Перекусы'],
+    ),
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Транспорт',
+      ['Общественный', 'Такси', 'Топливо', 'Парковка'],
+    ),
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Дом',
+      [
+        'Аренда',
+        'Коммунальные',
+        'Интернет/Связь',
+        'Обслуживание/Ремонт',
+      ],
+    ),
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Здоровье',
+      ['Аптека', 'Врач/Исследования', 'Страховка'],
+    ),
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Личное/Уход',
+      ['Косметика', 'Парикмахер/Салон'],
+    ),
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Образование',
+      ['Курсы', 'Книги/Материалы'],
+    ),
+    _DefaultCategoryGroup(
+      CategoryType.expense,
+      'Развлечения',
+      ['Кино/Театр', 'Игры', 'Прочее'],
+    ),
+  ];
+}
+
+List<_DefaultCategoryEntry> _defaultStandalone() {
+  return const [
+    _DefaultCategoryEntry(CategoryType.expense, 'Подписки'),
+    _DefaultCategoryEntry(CategoryType.expense, 'Одежда/Обувь'),
+    _DefaultCategoryEntry(CategoryType.expense, 'Подарки'),
+    _DefaultCategoryEntry(CategoryType.expense, 'Питомцы'),
+    _DefaultCategoryEntry(CategoryType.expense, 'Электроника'),
+    _DefaultCategoryEntry(CategoryType.expense, 'Налоги/Сборы'),
+    _DefaultCategoryEntry(CategoryType.expense, 'Другое'),
+    _DefaultCategoryEntry(CategoryType.income, 'Зарплата'),
+    _DefaultCategoryEntry(CategoryType.income, 'Аванс'),
+    _DefaultCategoryEntry(CategoryType.income, 'Премии/Бонусы'),
+    _DefaultCategoryEntry(CategoryType.income, 'Фриланс/Подработка'),
+    _DefaultCategoryEntry(CategoryType.income, 'Подарки'),
+    _DefaultCategoryEntry(CategoryType.income, 'Проценты/Кэшбэк'),
+    _DefaultCategoryEntry(CategoryType.income, 'Другое'),
+    _DefaultCategoryEntry(CategoryType.saving, 'Резервный фонд'),
+    _DefaultCategoryEntry(CategoryType.saving, 'Крупные цели'),
+    _DefaultCategoryEntry(CategoryType.saving, 'Короткие цели'),
+  ];
+}

--- a/lib/data/repositories/payouts_repository.dart
+++ b/lib/data/repositories/payouts_repository.dart
@@ -1,0 +1,72 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+import '../models/payout.dart';
+
+abstract class PayoutsRepository {
+  Future<int> add(
+    PayoutType type,
+    DateTime date,
+    int amountMinor, {
+    int? accountId,
+  });
+
+  Future<Payout?> getLast();
+
+  Future<List<Payout>> getHistory(int limit);
+}
+
+class SqlitePayoutsRepository implements PayoutsRepository {
+  SqlitePayoutsRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<int> add(
+    PayoutType type,
+    DateTime date,
+    int amountMinor, {
+    int? accountId,
+  }) async {
+    if (accountId == null) {
+      throw ArgumentError('accountId is required for payouts');
+    }
+    final db = await _db;
+    final payout = Payout(
+      type: type,
+      date: date,
+      amountMinor: amountMinor,
+      accountId: accountId,
+    );
+    final values = payout.toMap()..remove('id');
+    return db.insert('payouts', values);
+  }
+
+  @override
+  Future<List<Payout>> getHistory(int limit) async {
+    final db = await _db;
+    final rows = await db.query(
+      'payouts',
+      orderBy: 'date DESC, id DESC',
+      limit: limit,
+    );
+    return rows.map(Payout.fromMap).toList();
+  }
+
+  @override
+  Future<Payout?> getLast() async {
+    final db = await _db;
+    final rows = await db.query(
+      'payouts',
+      orderBy: 'date DESC, id DESC',
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return Payout.fromMap(rows.first);
+  }
+}

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -1,0 +1,137 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+
+abstract class SettingsRepository {
+  Future<int> getAnchorDay1();
+
+  Future<void> setAnchorDay1(int value);
+
+  Future<int> getAnchorDay2();
+
+  Future<void> setAnchorDay2(int value);
+
+  Future<int?> getDailyLimitMinor();
+
+  Future<void> setDailyLimitMinor(int? value);
+
+  Future<bool> getSavingPairEnabled();
+
+  Future<void> setSavingPairEnabled(bool value);
+}
+
+class SqliteSettingsRepository implements SettingsRepository {
+  SqliteSettingsRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  static const String _anchorDay1Key = 'anchor_day_1';
+  static const String _anchorDay2Key = 'anchor_day_2';
+  static const String _dailyLimitKey = 'daily_limit_minor';
+  static const String _savingPairKey = 'saving_pair_enabled';
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<int> getAnchorDay1() => _getInt(_anchorDay1Key, defaultValue: 1);
+
+  @override
+  Future<int> getAnchorDay2() => _getInt(_anchorDay2Key, defaultValue: 15);
+
+  @override
+  Future<int?> getDailyLimitMinor() => _getNullableInt(_dailyLimitKey);
+
+  @override
+  Future<bool> getSavingPairEnabled() => _getBool(_savingPairKey);
+
+  @override
+  Future<void> setAnchorDay1(int value) => _setInt(_anchorDay1Key, value);
+
+  @override
+  Future<void> setAnchorDay2(int value) => _setInt(_anchorDay2Key, value);
+
+  @override
+  Future<void> setDailyLimitMinor(int? value) => _setNullableInt(_dailyLimitKey, value);
+
+  @override
+  Future<void> setSavingPairEnabled(bool value) => _setBool(_savingPairKey, value);
+
+  Future<int> _getInt(String key, {required int defaultValue}) async {
+    final db = await _db;
+    final rows = await db.query(
+      'settings',
+      columns: ['value'],
+      where: 'key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      await _setInt(key, defaultValue);
+      return defaultValue;
+    }
+    return int.tryParse(rows.first['value'] as String? ?? '') ?? defaultValue;
+  }
+
+  Future<int?> _getNullableInt(String key) async {
+    final db = await _db;
+    final rows = await db.query(
+      'settings',
+      columns: ['value'],
+      where: 'key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return int.tryParse(rows.first['value'] as String? ?? '');
+  }
+
+  Future<bool> _getBool(String key) async {
+    final db = await _db;
+    final rows = await db.query(
+      'settings',
+      columns: ['value'],
+      where: 'key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      await _setBool(key, false);
+      return false;
+    }
+    final raw = rows.first['value'] as String?;
+    if (raw == null) {
+      return false;
+    }
+    return raw == '1' || raw.toLowerCase() == 'true';
+  }
+
+  Future<void> _setInt(String key, int value) async {
+    final db = await _db;
+    await db.insert(
+      'settings',
+      {'key': key, 'value': value.toString()},
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> _setNullableInt(String key, int? value) async {
+    final db = await _db;
+    if (value == null) {
+      await db.delete('settings', where: 'key = ?', whereArgs: [key]);
+    } else {
+      await _setInt(key, value);
+    }
+  }
+
+  Future<void> _setBool(String key, bool value) async {
+    final db = await _db;
+    await db.insert(
+      'settings',
+      {'key': key, 'value': value ? '1' : '0'},
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+}

--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -1,0 +1,202 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+import '../models/category.dart';
+import '../models/transaction_record.dart';
+import 'accounts_repository.dart';
+
+abstract class TransactionsRepository {
+  Future<TransactionRecord?> getById(int id);
+
+  Future<List<TransactionRecord>> getAll();
+
+  Future<List<TransactionRecord>> getByPeriod(
+    DateTime from,
+    DateTime to, {
+    int? accountId,
+    int? categoryId,
+    bool? isPlanned,
+    bool? includedInPeriod,
+  });
+
+  Future<int> add(TransactionRecord record, {bool asSavingPair = false});
+
+  Future<void> update(TransactionRecord record);
+
+  Future<void> delete(int id);
+}
+
+class SqliteTransactionsRepository implements TransactionsRepository {
+  SqliteTransactionsRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<int> add(TransactionRecord record, {bool asSavingPair = false}) async {
+    final db = await _db;
+    return db.transaction((txn) async {
+      final categoryType = await _getCategoryType(txn, record.categoryId);
+      final adjustedRecord = record.copyWith(
+        id: null,
+        type: categoryType == CategoryType.saving
+            ? TransactionType.saving
+            : record.type,
+      );
+      final primaryValues = Map<String, Object?>.from(adjustedRecord.toMap())
+        ..remove('id');
+      final primaryId = await txn.insert('transactions', primaryValues);
+
+      if (asSavingPair && categoryType == CategoryType.saving) {
+        final savingsAccountId = await _findSavingsAccountId(txn);
+        if (savingsAccountId == null) {
+          throw StateError(
+            'Счёт "${SqliteAccountsRepository.savingsAccountName}" не найден',
+          );
+        }
+        if (savingsAccountId != record.accountId) {
+          final pairRecord = adjustedRecord.copyWith(
+            id: null,
+            accountId: savingsAccountId,
+          );
+          final pairValues = Map<String, Object?>.from(pairRecord.toMap())
+            ..remove('id');
+          await txn.insert('transactions', pairValues);
+        }
+      }
+
+      return primaryId;
+    });
+  }
+
+  @override
+  Future<void> delete(int id) async {
+    final db = await _db;
+    await db.delete('transactions', where: 'id = ?', whereArgs: [id]);
+  }
+
+  @override
+  Future<List<TransactionRecord>> getAll() async {
+    final db = await _db;
+    final rows = await db.query('transactions', orderBy: 'date DESC, id DESC');
+    return rows.map(TransactionRecord.fromMap).toList();
+  }
+
+  @override
+  Future<TransactionRecord?> getById(int id) async {
+    final db = await _db;
+    final rows = await db.query(
+      'transactions',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return TransactionRecord.fromMap(rows.first);
+  }
+
+  @override
+  Future<List<TransactionRecord>> getByPeriod(
+    DateTime from,
+    DateTime to, {
+    int? accountId,
+    int? categoryId,
+    bool? isPlanned,
+    bool? includedInPeriod,
+  }) async {
+    final db = await _db;
+    final where = StringBuffer('date >= ? AND date <= ?');
+    final args = <Object?>[_formatDate(from), _formatDate(to)];
+
+    if (accountId != null) {
+      where.write(' AND account_id = ?');
+      args.add(accountId);
+    }
+    if (categoryId != null) {
+      where.write(' AND category_id = ?');
+      args.add(categoryId);
+    }
+    if (isPlanned != null) {
+      where.write(' AND is_planned = ?');
+      args.add(isPlanned ? 1 : 0);
+    }
+    if (includedInPeriod != null) {
+      where.write(' AND included_in_period = ?');
+      args.add(includedInPeriod ? 1 : 0);
+    }
+
+    final rows = await db.query(
+      'transactions',
+      where: where.toString(),
+      whereArgs: args,
+      orderBy: 'date DESC, id DESC',
+    );
+    return rows.map(TransactionRecord.fromMap).toList();
+  }
+
+  @override
+  Future<void> update(TransactionRecord record) async {
+    final id = record.id;
+    if (id == null) {
+      throw ArgumentError('Transaction id is required for update');
+    }
+    final db = await _db;
+    await db.update(
+      'transactions',
+      record.toMap(),
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<CategoryType> _getCategoryType(DatabaseExecutor executor, int id) async {
+    final rows = await executor.query(
+      'categories',
+      columns: ['type'],
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      throw ArgumentError.value(id, 'id', 'Category not found');
+    }
+    return _typeFromString(rows.first['type'] as String?);
+  }
+
+  Future<int?> _findSavingsAccountId(DatabaseExecutor executor) async {
+    final rows = await executor.query(
+      'accounts',
+      columns: ['id', 'name'],
+      where: 'LOWER(name) = ?',
+      whereArgs: [SqliteAccountsRepository.savingsAccountName.toLowerCase()],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return rows.first['id'] as int?;
+  }
+
+  String _formatDate(DateTime date) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '${date.year.toString().padLeft(4, '0')}-$month-$day';
+  }
+
+  CategoryType _typeFromString(String? raw) {
+    switch (raw) {
+      case 'income':
+        return CategoryType.income;
+      case 'expense':
+        return CategoryType.expense;
+      case 'saving':
+        return CategoryType.saving;
+      default:
+        throw ArgumentError.value(raw, 'raw', 'Unknown category type');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add domain models for accounts, categories, transactions and payouts
- implement SQLite-backed repositories for accounts, categories, transactions, payouts and settings
- support restoring default categories, saving-pair transactions, and computed account balances

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf8f3829748326aaaab8b8ab17ff9d