### PR TITLE
Add repository-backed providers and budget calculations

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -1,19 +1,68 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../data/mock/mock_models.dart';
-import '../data/mock/mock_repositories.dart';
+import '../data/db/app_database.dart';
+import '../data/mock/mock_models.dart' as mock;
+import '../data/mock/mock_repositories.dart' as mock_repo;
+import '../data/repositories/accounts_repository.dart' as accounts_repo;
+import '../data/repositories/categories_repository.dart' as categories_repo;
+import '../data/repositories/payouts_repository.dart' as payouts_repo;
+import '../data/repositories/settings_repository.dart' as settings_repo;
+import '../data/repositories/transactions_repository.dart' as transactions_repo;
 
-final budgetPeriodRepositoryProvider = Provider<BudgetPeriodRepository>((ref) {
-  return BudgetPeriodRepository();
+final appDatabaseProvider = Provider<AppDatabase>((ref) => AppDatabase.instance);
+
+final accountsRepoProvider =
+    Provider<accounts_repo.AccountsRepository>((ref) {
+  final database = ref.watch(appDatabaseProvider);
+  return accounts_repo.SqliteAccountsRepository(database: database);
+});
+
+final categoriesRepoProvider =
+    Provider<categories_repo.CategoriesRepository>((ref) {
+  final database = ref.watch(appDatabaseProvider);
+  return categories_repo.SqliteCategoriesRepository(database: database);
+});
+
+final transactionsRepoProvider =
+    Provider<transactions_repo.TransactionsRepository>((ref) {
+  final database = ref.watch(appDatabaseProvider);
+  return transactions_repo.SqliteTransactionsRepository(database: database);
+});
+
+final payoutsRepoProvider = Provider<payouts_repo.PayoutsRepository>((ref) {
+  final database = ref.watch(appDatabaseProvider);
+  return payouts_repo.SqlitePayoutsRepository(database: database);
+});
+
+final settingsRepoProvider = Provider<settings_repo.SettingsRepository>((ref) {
+  final database = ref.watch(appDatabaseProvider);
+  return settings_repo.SqliteSettingsRepository(database: database);
+});
+
+final computedBalanceProvider =
+    FutureProvider.family<int, int>((ref, accountId) async {
+  final repository = ref.watch(accountsRepoProvider);
+  return repository.getComputedBalanceMinor(accountId);
+});
+
+final reconcileAccountProvider =
+    Provider<Future<void> Function(int)>((ref) {
+  final repository = ref.watch(accountsRepoProvider);
+  return (accountId) => repository.reconcileToComputed(accountId);
+});
+
+final budgetPeriodRepositoryProvider =
+    Provider<mock_repo.BudgetPeriodRepository>((ref) {
+  return mock_repo.BudgetPeriodRepository();
 });
 
 final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.system);
 
-class ActivePeriodNotifier extends StateNotifier<BudgetPeriod> {
+class ActivePeriodNotifier extends StateNotifier<mock.BudgetPeriod> {
   ActivePeriodNotifier(this._repository) : super(_repository.activePeriod);
 
-  final BudgetPeriodRepository _repository;
+  final mock_repo.BudgetPeriodRepository _repository;
 
   void setActive(String id) {
     _repository.setActive(id);
@@ -22,37 +71,39 @@ class ActivePeriodNotifier extends StateNotifier<BudgetPeriod> {
 }
 
 final activePeriodProvider =
-    StateNotifierProvider<ActivePeriodNotifier, BudgetPeriod>((ref) {
+    StateNotifierProvider<ActivePeriodNotifier, mock.BudgetPeriod>((ref) {
   final repository = ref.watch(budgetPeriodRepositoryProvider);
   return ActivePeriodNotifier(repository);
 });
 
-final periodsProvider = Provider<List<BudgetPeriod>>((ref) {
+final periodsProvider = Provider<List<mock.BudgetPeriod>>((ref) {
   final repository = ref.watch(budgetPeriodRepositoryProvider);
   return repository.periods;
 });
 
-final accountsRepositoryProvider = Provider<AccountsRepository>((ref) {
-  return AccountsRepository();
+final accountsRepositoryProvider =
+    Provider<mock_repo.AccountsRepository>((ref) {
+  return mock_repo.AccountsRepository();
 });
 
 final categoriesRepositoryProvider =
-    ChangeNotifierProvider<CategoriesRepository>((ref) {
-  return CategoriesRepository();
+    ChangeNotifierProvider<mock_repo.CategoriesRepository>((ref) {
+  return mock_repo.CategoriesRepository();
 });
 
-final operationsRepositoryProvider = Provider<OperationsRepository>((ref) {
-  return OperationsRepository();
+final operationsRepositoryProvider =
+    Provider<mock_repo.OperationsRepository>((ref) {
+  return mock_repo.OperationsRepository();
 });
 
 final isSheetOpenProvider = StateProvider<bool>((_) => false);
 
-final accountsProvider = Provider<List<Account>>((ref) {
+final accountsProvider = Provider<List<mock.Account>>((ref) {
   final repository = ref.watch(accountsRepositoryProvider);
   return repository.getAccounts();
 });
 
-final activePeriodOperationsProvider = Provider<List<Operation>>((ref) {
+final activePeriodOperationsProvider = Provider<List<mock.Operation>>((ref) {
   final period = ref.watch(activePeriodProvider);
   final repository = ref.watch(operationsRepositoryProvider);
   final categoriesRepository = ref.watch(categoriesRepositoryProvider);
@@ -87,15 +138,19 @@ final periodSummaryProvider = Provider<PeriodSummary>((ref) {
   final period = ref.watch(activePeriodProvider);
   final repository = ref.watch(operationsRepositoryProvider);
 
-  final totalIncome = repository.totalForType(period.id, OperationType.income);
-  final totalExpense = repository.totalForType(period.id, OperationType.expense);
-  final totalSavings = repository.totalForType(period.id, OperationType.savings);
+  final totalIncome =
+      repository.totalForType(period.id, mock.OperationType.income);
+  final totalExpense =
+      repository.totalForType(period.id, mock.OperationType.expense);
+  final totalSavings =
+      repository.totalForType(period.id, mock.OperationType.savings);
   final remainingBudget = totalIncome - totalExpense - totalSavings;
 
   final now = DateTime.now();
   final today = DateTime(now.year, now.month, now.day);
   final periodEnd = DateTime(period.end.year, period.end.month, period.end.day);
-  final periodStart = DateTime(period.start.year, period.start.month, period.start.day);
+  final periodStart =
+      DateTime(period.start.year, period.start.month, period.start.day);
   int daysLeft;
   if (today.isBefore(periodStart)) {
     daysLeft = periodEnd.difference(periodStart).inDays + 1;
@@ -105,7 +160,8 @@ final periodSummaryProvider = Provider<PeriodSummary>((ref) {
     daysLeft = periodEnd.difference(today).inDays + 1;
   }
 
-  final todayBudget = daysLeft > 0 ? remainingBudget / daysLeft : remainingBudget;
+  final todayBudget =
+      daysLeft > 0 ? remainingBudget / daysLeft : remainingBudget;
   final todaySpent = repository.spentOnDate(period.id, now);
   final normalizedBudget = todayBudget <= 0 ? 1.0 : todayBudget;
   final progress = (todaySpent / normalizedBudget).clamp(0.0, 1.0);
@@ -115,7 +171,8 @@ final periodSummaryProvider = Provider<PeriodSummary>((ref) {
     totalExpense: totalExpense,
     totalSavings: totalSavings,
     remainingBudget: remainingBudget,
-    remainingPerDay: daysLeft > 0 ? remainingBudget / daysLeft : remainingBudget,
+    remainingPerDay:
+        daysLeft > 0 ? remainingBudget / daysLeft : remainingBudget,
     todaySpent: todaySpent,
     todayBudget: todayBudget,
     dailyProgress: progress,

--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -1,0 +1,168 @@
+import 'dart:math' as math;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/models/payout.dart';
+import 'app_providers.dart';
+
+typedef BudgetPeriodInfo = ({DateTime start, DateTime end, int days});
+
+final anchorDaysProvider = FutureProvider<(int, int)>((ref) async {
+  final repository = ref.watch(settingsRepoProvider);
+  final day1 = await repository.getAnchorDay1();
+  final day2 = await repository.getAnchorDay2();
+  final anchors = [day1, day2]..sort();
+  final first = _normalizeAnchorDay(anchors[0]);
+  final second = _normalizeAnchorDay(anchors[1]);
+  return (first, second);
+});
+
+final currentPayoutProvider = FutureProvider<Payout?>((ref) {
+  final repository = ref.watch(payoutsRepoProvider);
+  return repository.getLast();
+});
+
+final currentPeriodProvider = FutureProvider<BudgetPeriodInfo>((ref) async {
+  final (anchor1, anchor2) = await ref.watch(anchorDaysProvider.future);
+  final payout = await ref.watch(currentPayoutProvider.future);
+  final now = _normalizeDate(DateTime.now());
+  final start = payout != null
+      ? _normalizeDate(payout.date)
+      : _previousAnchorDate(
+          _nextAnchorDate(now, anchor1, anchor2),
+          anchor1,
+          anchor2,
+        );
+
+  var end = _nextAnchorDate(start, anchor1, anchor2);
+  if (!end.isAfter(start)) {
+    end = _nextAnchorDate(end.add(const Duration(days: 1)), anchor1, anchor2);
+  }
+
+  var days = end.difference(start).inDays;
+  if (days <= 0) {
+    days = 1;
+  }
+
+  return (start: start, end: end, days: days);
+});
+
+final dailyLimitProvider = FutureProvider<int?>((ref) async {
+  final repository = ref.watch(settingsRepoProvider);
+  return repository.getDailyLimitMinor();
+});
+
+final periodBudgetMinorProvider = FutureProvider<int>((ref) async {
+  final dailyLimit = await ref.watch(dailyLimitProvider.future) ?? 0;
+  if (dailyLimit <= 0) {
+    return 0;
+  }
+  final period = await ref.watch(currentPeriodProvider.future);
+  final today = _normalizeDate(DateTime.now());
+  final rawRemaining = period.end.difference(today).inDays;
+  final remainingDays = _clampRemainingDays(rawRemaining, period.days);
+  if (remainingDays <= 0) {
+    return 0;
+  }
+  return dailyLimit * remainingDays;
+});
+
+final plannedPoolMinorProvider = FutureProvider<int>((ref) async {
+  final payout = await ref.watch(currentPayoutProvider.future);
+  if (payout == null) {
+    return 0;
+  }
+  final periodBudget = await ref.watch(periodBudgetMinorProvider.future);
+  final pool = payout.amountMinor - periodBudget;
+  return math.max(pool, 0);
+});
+
+final dailyLimitManagerProvider = Provider<DailyLimitManager>((ref) {
+  return DailyLimitManager(ref);
+});
+
+class DailyLimitManager {
+  DailyLimitManager(this._ref);
+
+  final Ref _ref;
+
+  Future<String?> saveDailyLimitMinor(int? value) async {
+    if (value != null) {
+      final payout = await _ref.read(currentPayoutProvider.future);
+      if (payout != null) {
+        final period = await _ref.read(currentPeriodProvider.future);
+        final periodDays = period.days;
+        if (periodDays > 0) {
+          final maxDaily = payout.amountMinor ~/ periodDays;
+          if (value > maxDaily) {
+            return 'Лимит не может превышать $maxDaily';
+          }
+        }
+      }
+    }
+
+    final repository = _ref.read(settingsRepoProvider);
+    await repository.setDailyLimitMinor(value);
+    return null;
+  }
+}
+
+int _normalizeAnchorDay(int value) {
+  if (value < 1) {
+    return 1;
+  }
+  if (value > 31) {
+    return 31;
+  }
+  return value;
+}
+
+DateTime _normalizeDate(DateTime date) {
+  return DateTime(date.year, date.month, date.day);
+}
+
+DateTime _nextAnchorDate(DateTime from, int anchor1, int anchor2) {
+  final normalized = _normalizeDate(from);
+  final smaller = math.min(anchor1, anchor2);
+  final larger = math.max(anchor1, anchor2);
+
+  if (normalized.day < larger) {
+    return _anchorDate(normalized.year, normalized.month, larger);
+  }
+
+  final nextMonth = DateTime(normalized.year, normalized.month + 1, 1);
+  return _anchorDate(nextMonth.year, nextMonth.month, smaller);
+}
+
+DateTime _previousAnchorDate(DateTime from, int anchor1, int anchor2) {
+  final normalized = _normalizeDate(from);
+  final smaller = math.min(anchor1, anchor2);
+  final larger = math.max(anchor1, anchor2);
+
+  if (normalized.day <= smaller) {
+    final previousMonth = DateTime(normalized.year, normalized.month - 1, 1);
+    return _anchorDate(previousMonth.year, previousMonth.month, larger);
+  }
+
+  if (normalized.day <= larger) {
+    return _anchorDate(normalized.year, normalized.month, smaller);
+  }
+
+  return _anchorDate(normalized.year, normalized.month, larger);
+}
+
+DateTime _anchorDate(int year, int month, int day) {
+  final lastDay = DateTime(year, month + 1, 0).day;
+  final safeDay = day.clamp(1, lastDay);
+  return DateTime(year, month, safeDay);
+}
+
+int _clampRemainingDays(int difference, int periodDays) {
+  if (difference <= 0) {
+    return 0;
+  }
+  if (difference >= periodDays) {
+    return periodDays;
+  }
+  return difference;
+}


### PR DESCRIPTION
## Summary
- connect application providers to the sqlite-backed repositories and expose account helper providers
- add budget providers for anchor days, current period, daily limit, and planned pool calculations
- implement daily limit validation that enforces the maximum based on the latest payout

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf93615fa88326820b647440fe64cd