### PR TITLE
Integrate budget and payouts providers into UI

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/db/app_database.dart';
+import '../data/models/account.dart' as db_models;
 import '../data/mock/mock_models.dart' as mock;
 import '../data/mock/mock_repositories.dart' as mock_repo;
 import '../data/repositories/accounts_repository.dart' as accounts_repo;
@@ -16,6 +17,11 @@ final accountsRepoProvider =
     Provider<accounts_repo.AccountsRepository>((ref) {
   final database = ref.watch(appDatabaseProvider);
   return accounts_repo.SqliteAccountsRepository(database: database);
+});
+
+final accountsDbProvider = FutureProvider<List<db_models.Account>>((ref) {
+  final repository = ref.watch(accountsRepoProvider);
+  return repository.getAll();
 });
 
 final categoriesRepoProvider =

--- a/lib/ui/accounts/accounts_list_stub.dart
+++ b/lib/ui/accounts/accounts_list_stub.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../data/models/account.dart' as db_models;
 import '../../routing/app_router.dart';
 import '../../state/app_providers.dart';
 import '../../utils/formatting.dart';
@@ -11,7 +12,7 @@ class AccountsListStub extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accounts = ref.watch(accountsProvider);
+    final accountsAsync = ref.watch(accountsDbProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -24,27 +25,120 @@ class AccountsListStub extends ConsumerWidget {
           ),
         ],
       ),
-      body: ListView.builder(
-        padding: const EdgeInsets.all(24),
-        itemCount: accounts.length,
-        itemBuilder: (context, index) {
-          final account = accounts[index];
-          return Card(
-            child: ListTile(
-              leading: CircleAvatar(
-                backgroundColor: account.color.withOpacity(0.15),
-                child: Icon(Icons.account_balance_wallet, color: account.color),
+      body: accountsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('Не удалось загрузить счета: $error'),
+          ),
+        ),
+        data: (accounts) {
+          if (accounts.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text('Добавьте первый счёт, чтобы следить за балансом.'),
               ),
-              title: Text(account.name),
-              subtitle: Text(formatCurrency(account.balance)),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => context.pushNamed(
-                RouteNames.accountEdit,
-                extra: account.name,
-              ),
-            ),
+            );
+          }
+          return ListView.builder(
+            padding: const EdgeInsets.all(24),
+            itemCount: accounts.length,
+            itemBuilder: (context, index) {
+              final account = accounts[index];
+              return _AccountListTile(account: account);
+            },
           );
         },
+      ),
+    );
+  }
+}
+
+class _AccountListTile extends ConsumerWidget {
+  const _AccountListTile({required this.account});
+
+  final db_models.Account account;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accountId = account.id;
+    if (accountId == null) {
+      return const SizedBox.shrink();
+    }
+    final computedAsync = ref.watch(computedBalanceProvider(accountId));
+    final reconcile = ref.read(reconcileAccountProvider);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ListTile(
+              leading: const CircleAvatar(
+                child: Icon(Icons.account_balance_wallet),
+              ),
+              title: Text(account.name),
+              subtitle: Text(
+                'Текущий: ${formatCurrencyMinor(account.startBalanceMinor)}',
+              ),
+              trailing: IconButton(
+                icon: const Icon(Icons.chevron_right),
+                onPressed: () => context.pushNamed(
+                  RouteNames.accountEdit,
+                  extra: account.name,
+                ),
+              ),
+            ),
+            computedAsync.when(
+              data: (computed) {
+                final difference = computed - account.startBalanceMinor;
+                final differenceText = difference == 0
+                    ? 'Расхождений нет'
+                    : 'Расхождение: ${formatCurrencyMinor(difference)}';
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Рассчитанный баланс: ${formatCurrencyMinor(computed)}'),
+                      const SizedBox(height: 4),
+                      Text(
+                        differenceText,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      if (difference != 0)
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton(
+                            onPressed: () async {
+                              await reconcile(accountId);
+                              ref.invalidate(accountsDbProvider);
+                              ref.invalidate(computedBalanceProvider(accountId));
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Баланс выровнен')),
+                              );
+                            },
+                            child: const Text('Выровнять'),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+              loading: () => const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                child: LinearProgressIndicator(),
+              ),
+              error: (error, _) => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text('Не удалось рассчитать баланс: $error'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/operations/operations_screen.dart
+++ b/lib/ui/operations/operations_screen.dart
@@ -117,7 +117,9 @@ class _OperationsSection extends ConsumerWidget {
                       context: context,
                       builder: (context) => AlertDialog(
                         title: const Text('Удалить операцию?'),
-                        content: const Text('Это действие нельзя отменить.'),
+                        content: const Text(
+                          'Это действие нельзя отменить. Итоги периода будут пересчитаны.',
+                        ),
                         actions: [
                           TextButton(
                             onPressed: () => Navigator.of(context).pop(false),

--- a/lib/utils/formatting.dart
+++ b/lib/utils/formatting.dart
@@ -10,6 +10,17 @@ String formatCurrency(double value) {
   return currencyFormat.format(value);
 }
 
+String formatCurrencyMinor(int value) {
+  return formatCurrency(value / 100);
+}
+
+String formatCurrencyMinorNullable(int? value, {String placeholder = '—'}) {
+  if (value == null) {
+    return placeholder;
+  }
+  return formatCurrencyMinor(value);
+}
+
 String formatDate(DateTime date) {
   return DateFormat.yMMMMd('ru_RU').format(date);
 }


### PR DESCRIPTION
## Summary
- hook the home dashboard to the new budget providers, including an inline daily limit editor and planned pool insight
- add payouts management in settings so advances and salaries trigger provider refreshes
- surface computed account balances with a reconcile shortcut on the accounts list and home summary

## Testing
- not run (dart/flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf96ee8ae08326be5ac329ca4bade7