### PR TITLE
Implement database seeding and service actions

### DIFF
--- a/lib/data/bootstrap/app_bootstrapper.dart
+++ b/lib/data/bootstrap/app_bootstrapper.dart
@@ -1,0 +1,107 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+import '../repositories/categories_repository.dart';
+
+/// Seeds initial data required for the application on first launch.
+class AppBootstrapper {
+  AppBootstrapper({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  static const String _seedFlagKey = '_initial_seed_completed';
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  /// Ensures that the essential data is present in the database.
+  Future<void> run() async {
+    final db = await _db;
+    final alreadySeeded = await _isSeedCompleted(db);
+    if (alreadySeeded) {
+      return;
+    }
+
+    await db.transaction((txn) async {
+      await _seedAccounts(txn);
+      await _seedSettings(txn);
+      await _markSeedCompleted(txn);
+    });
+
+    // Seed categories separately to reuse repository helpers.
+    final categoriesRepository =
+        SqliteCategoriesRepository(database: _database);
+    await categoriesRepository.restoreDefaults();
+  }
+
+  Future<bool> _isSeedCompleted(DatabaseExecutor executor) async {
+    final rows = await executor.query(
+      'settings',
+      columns: ['value'],
+      where: 'key = ?',
+      whereArgs: [_seedFlagKey],
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
+  Future<void> _markSeedCompleted(DatabaseExecutor executor) async {
+    await executor.insert(
+      'settings',
+      {
+        'key': _seedFlagKey,
+        'value': '1',
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> _seedAccounts(DatabaseExecutor executor) async {
+    final count = Sqflite.firstIntValue(
+          await executor.rawQuery('SELECT COUNT(*) FROM accounts'),
+        ) ??
+        0;
+    if (count > 0) {
+      return;
+    }
+
+    final accounts = const [
+      ('Нал', 'RUB'),
+      ('Карта', 'RUB'),
+      ('Сберегательный', 'RUB'),
+    ];
+
+    for (final (name, currency) in accounts) {
+      await executor.insert(
+        'accounts',
+        {
+          'name': name,
+          'currency': currency,
+          'start_balance_minor': 0,
+          'is_archived': 0,
+        },
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+    }
+  }
+
+  Future<void> _seedSettings(DatabaseExecutor executor) async {
+    final defaults = <String, String>{
+      'anchor_day_1': '1',
+      'anchor_day_2': '15',
+      'daily_limit_minor': '0',
+      'saving_pair_enabled': '1',
+    };
+
+    for (final entry in defaults.entries) {
+      await executor.insert(
+        'settings',
+        {
+          'key': entry.key,
+          'value': entry.value,
+        },
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+    }
+  }
+}

--- a/lib/data/repositories/categories_repository.dart
+++ b/lib/data/repositories/categories_repository.dart
@@ -230,7 +230,14 @@ List<_DefaultCategoryGroup> _defaultGroups() {
     _DefaultCategoryGroup(
       CategoryType.expense,
       'Еда',
-      ['Магазины', 'Рестораны', 'Кафе', 'Доставка', 'Перекусы'],
+      [
+        'Продукты',
+        'Перекус',
+        'Сигареты',
+        'Доставка',
+        'Кафе',
+        'Рестораны',
+      ],
     ),
     _DefaultCategoryGroup(
       CategoryType.expense,
@@ -243,29 +250,29 @@ List<_DefaultCategoryGroup> _defaultGroups() {
       [
         'Аренда',
         'Коммунальные',
-        'Интернет/Связь',
-        'Обслуживание/Ремонт',
+        'Интернет',
+        'Ремонт',
       ],
     ),
     _DefaultCategoryGroup(
       CategoryType.expense,
       'Здоровье',
-      ['Аптека', 'Врач/Исследования', 'Страховка'],
+      ['Аптека', 'Врач', 'Страховка'],
     ),
     _DefaultCategoryGroup(
       CategoryType.expense,
       'Личное/Уход',
-      ['Косметика', 'Парикмахер/Салон'],
+      ['Косметика', 'Парикмахер'],
     ),
     _DefaultCategoryGroup(
       CategoryType.expense,
       'Образование',
-      ['Курсы', 'Книги/Материалы'],
+      ['Курсы', 'Книги'],
     ),
     _DefaultCategoryGroup(
       CategoryType.expense,
       'Развлечения',
-      ['Кино/Театр', 'Игры', 'Прочее'],
+      ['Кино', 'Игры', 'Прочее'],
     ),
   ];
 }
@@ -287,7 +294,6 @@ List<_DefaultCategoryEntry> _defaultStandalone() {
     _DefaultCategoryEntry(CategoryType.income, 'Проценты/Кэшбэк'),
     _DefaultCategoryEntry(CategoryType.income, 'Другое'),
     _DefaultCategoryEntry(CategoryType.saving, 'Резервный фонд'),
-    _DefaultCategoryEntry(CategoryType.saving, 'Крупные цели'),
-    _DefaultCategoryEntry(CategoryType.saving, 'Короткие цели'),
+    _DefaultCategoryEntry(CategoryType.saving, 'Цели'),
   ];
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,11 +4,15 @@ import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
 
 import 'app.dart';
+import 'data/bootstrap/app_bootstrapper.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   Intl.defaultLocale = 'ru_RU';
   await initializeDateFormatting('ru_RU');
+
+  final bootstrapper = AppBootstrapper();
+  await bootstrapper.run();
 
   runApp(const ProviderScope(child: FinanceApp()));
 }

--- a/lib/ui/payouts/add_payout_sheet.dart
+++ b/lib/ui/payouts/add_payout_sheet.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/payout.dart';
+import '../../state/app_providers.dart';
+import '../../state/budget_providers.dart';
+import '../../utils/formatting.dart';
+
+Future<bool> showAddPayoutSheet(
+  BuildContext context,
+  WidgetRef ref, {
+  required PayoutType type,
+}) async {
+  final accountsRepo = ref.read(accountsRepoProvider);
+  final payoutsRepo = ref.read(payoutsRepoProvider);
+  final accounts = await accountsRepo.getAll();
+
+  if (!context.mounted) {
+    return false;
+  }
+
+  if (accounts.isEmpty) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Сначала добавьте счёт.')),
+    );
+    return false;
+  }
+
+  final selectableAccounts =
+      accounts.where((account) => account.id != null).toList();
+  if (selectableAccounts.isEmpty) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Нет доступных счетов для выплаты.')),
+    );
+    return false;
+  }
+
+  final defaultAccount = selectableAccounts.firstWhere(
+    (account) => account.name.toLowerCase() == 'карта',
+    orElse: () => selectableAccounts.first,
+  );
+
+  var selectedAccountId = defaultAccount.id;
+  DateTime selectedDate = DateTime.now();
+  final amountController = TextEditingController();
+  String? errorText;
+  var isSaving = false;
+  var saved = false;
+
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (sheetContext) {
+      return Padding(
+        padding: EdgeInsets.only(
+          left: 24,
+          right: 24,
+          top: 24,
+          bottom: MediaQuery.of(sheetContext).viewInsets.bottom + 24,
+        ),
+        child: StatefulBuilder(
+          builder: (context, setState) {
+            Future<void> pickDate() async {
+              final picked = await showDatePicker(
+                context: sheetContext,
+                initialDate: selectedDate,
+                firstDate: DateTime.now().subtract(const Duration(days: 365)),
+                lastDate: DateTime.now().add(const Duration(days: 365)),
+              );
+              if (picked != null) {
+                setState(() => selectedDate = picked);
+              }
+            }
+
+            Future<void> save() async {
+              if (isSaving) {
+                return;
+              }
+              setState(() {
+                errorText = null;
+                isSaving = true;
+              });
+
+              final rawAmount =
+                  amountController.text.trim().replaceAll(',', '.');
+              final parsed = double.tryParse(rawAmount);
+              if (parsed == null || parsed <= 0) {
+                setState(() {
+                  errorText = 'Введите сумму больше нуля';
+                  isSaving = false;
+                });
+                return;
+              }
+
+              final accountId = selectedAccountId;
+              if (accountId == null) {
+                setState(() {
+                  errorText = 'Выберите счёт';
+                  isSaving = false;
+                });
+                return;
+              }
+
+              final amountMinor = (parsed * 100).round();
+              try {
+                await payoutsRepo.add(
+                  type,
+                  DateTime(
+                    selectedDate.year,
+                    selectedDate.month,
+                    selectedDate.day,
+                  ),
+                  amountMinor,
+                  accountId: accountId,
+                );
+              } catch (error) {
+                setState(() {
+                  errorText = 'Ошибка: $error';
+                  isSaving = false;
+                });
+                return;
+              }
+
+              saved = true;
+              Navigator.of(sheetContext).pop();
+            }
+
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  type == PayoutType.advance
+                      ? 'Добавить аванс'
+                      : 'Добавить зарплату',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 12),
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Дата'),
+                  subtitle: Text(formatDate(selectedDate)),
+                  trailing: const Icon(Icons.calendar_today),
+                  onTap: pickDate,
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: amountController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
+                  decoration: InputDecoration(
+                    labelText: 'Сумма',
+                    prefixText: '₽ ',
+                    errorText: errorText,
+                  ),
+                  onChanged: (_) {
+                    if (errorText != null) {
+                      setState(() => errorText = null);
+                    }
+                  },
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<int>(
+                  value: selectedAccountId,
+                  decoration: const InputDecoration(labelText: 'Счёт'),
+                  items: [
+                    for (final account in selectableAccounts)
+                      DropdownMenuItem(
+                        value: account.id,
+                        child: Text(account.name),
+                      ),
+                  ],
+                  onChanged: (value) => setState(() {
+                    selectedAccountId = value;
+                  }),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    TextButton(
+                      onPressed: isSaving
+                          ? null
+                          : () {
+                              amountController.clear();
+                              setState(() => errorText = null);
+                            },
+                      child: const Text('Очистить сумму'),
+                    ),
+                    const Spacer(),
+                    FilledButton(
+                      onPressed: isSaving ? null : save,
+                      child: isSaving
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('Сохранить'),
+                    ),
+                  ],
+                ),
+              ],
+            );
+          },
+        ),
+      );
+    },
+  );
+
+  amountController.dispose();
+
+  if (!context.mounted) {
+    return saved;
+  }
+
+  if (saved) {
+    ref.invalidate(currentPayoutProvider);
+    ref.invalidate(currentPeriodProvider);
+    ref.invalidate(periodBudgetMinorProvider);
+    ref.invalidate(plannedPoolMinorProvider);
+  }
+
+  return saved;
+}


### PR DESCRIPTION
## Summary
- add an application bootstrapper that seeds default accounts, settings, and categories on first launch and wire it into main
- refresh the default category lists and settings defaults to match the new specification
- update budget helpers with anchor-day invalidation, reusable payout sheet logic, and UI hooks for adding payouts and restoring default categories

## Testing
- flutter clean *(fails: command not found)*
- flutter pub get *(fails: command not found)*
- flutter analyze *(fails: command not found)*
- flutter run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9f15615c83269e4d7271e34af5e9