### PR TITLE
Fix build errors in home and category views

### DIFF
--- a/lib/ui/categories/category_tree_view.dart
+++ b/lib/ui/categories/category_tree_view.dart
@@ -45,7 +45,7 @@ class CategoryTreeView extends StatelessWidget {
         children: childrenByGroup[group.id] ?? const <Category>[],
         onCategoryTap: onCategoryTap,
         onCategoryLongPress: onCategoryLongPress,
-        onGroupTap: onGroupTap,
+        onGroupTap: onGroupTap != null ? () => onGroupTap!(group) : null,
         onGroupLongPress: onGroupLongPress,
       ));
       items.add(const SizedBox(height: 12));
@@ -99,7 +99,7 @@ class _GroupCard extends StatefulWidget {
   final List<Category> children;
   final CategoryCallback? onCategoryTap;
   final CategoryCallback? onCategoryLongPress;
-  final CategoryCallback? onGroupTap;
+  final VoidCallback? onGroupTap;
   final CategoryCallback? onGroupLongPress;
 
   @override

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -292,12 +292,12 @@ class HomeScreen extends ConsumerWidget {
     final dailyLimitLabel = dailyLimitAsync.when(
       data: (value) => formatCurrencyMinorNullable(value),
       loading: () => '…',
-      error: (_) => '—',
+      error: (e, st) => '—',
     );
     final periodBudgetLabel = periodBudgetAsync.when(
       data: (value) => formatCurrencyMinor(value),
       loading: () => '…',
-      error: (_) => '—',
+      error: (e, st) => '—',
     );
 
     return Row(


### PR DESCRIPTION
## Summary
- update AsyncValue error callbacks in the home screen to accept both error and stack trace parameters
- adjust category group tap handling to use a VoidCallback and wrap the category-aware handler

## Testing
- flutter clean *(fails: flutter not installed in container)*
- flutter pub get *(fails: flutter not installed in container)*
- flutter analyze *(fails: flutter not installed in container)*
- flutter run *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa6d98f488326ae4bf2343024df43