### PR TITLE
Fix planned sheet form arguments and add compatibility getters

### DIFF
--- a/lib/state/planned_providers.dart
+++ b/lib/state/planned_providers.dart
@@ -34,6 +34,8 @@ class PlannedItemView {
 
   bool get isCompleted => record.includedInPeriod;
 
+  bool get isDone => isCompleted;
+
   String get title {
     final note = record.note;
     if (note != null && note.trim().isNotEmpty) {

--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -63,7 +63,6 @@ class ReviewScreen extends ConsumerWidget {
         asSavingPair: entryState.type == mock.OperationType.savings,
       );
 
-      ref.invalidate(halfPeriodTransactionsProvider);
       ref.invalidate(computedBalanceProvider(accountId));
       controller.reset();
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/ui/planned/planned_add_form.dart
+++ b/lib/ui/planned/planned_add_form.dart
@@ -86,6 +86,8 @@ class _PlannedAddFormState extends State<_PlannedAddForm> {
   final _nameController = TextEditingController();
   final _amountController = TextEditingController();
 
+  int? get _editingId => widget.initialRecord?.id;
+
   late Future<List<Category>> _categoriesFuture;
   int? _selectedCategoryId;
   int _selectedCriticality = 0;
@@ -346,7 +348,7 @@ class _PlannedAddFormState extends State<_PlannedAddForm> {
       PlannedType.expense => 'расход',
       PlannedType.saving => 'сбережение',
     };
-    return widget.editId == null
+    return _editingId == null
         ? 'Добавить $base'
         : 'Редактировать $base';
   }

--- a/lib/ui/planned/planned_sheet.dart
+++ b/lib/ui/planned/planned_sheet.dart
@@ -133,6 +133,7 @@ Future<void> showPlannedSheet(
                     } else if (action == _PlannedItemAction.edit) {
                       await showPlannedAddForm(
                         ctx,
+                        sheetRef,
                         type: type,
                         initialRecord: item.record,
                       );
@@ -224,6 +225,7 @@ Future<void> showPlannedSheet(
                         FilledButton.icon(
                           onPressed: () => showPlannedAddForm(
                             ctx,
+                            sheetRef,
                             type: type,
                           ),
                           icon: const Icon(Icons.add),


### PR DESCRIPTION
## Summary
- remove the invalidation of a non-existent half-period transactions provider from the review screen
- pass the WidgetRef and planned type into planned item add form invocations from the planned sheet
- expose an `isDone` getter on `PlannedItemView` and adjust the planned add form to derive edit state from the initial record

## Testing
- `flutter analyze` *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d01f4081108326bb586ad9913b9bbb