### PR TITLE
Fix necessity labels provider type mismatch

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -105,7 +105,7 @@ final categoriesRepositoryProvider =
 
 final isSheetOpenProvider = StateProvider<bool>((_) => false);
 
-final necessityLabelsProvider =
+final necessityLabelsFutureProvider =
     FutureProvider<List<necessity_repo.NecessityLabel>>((ref) {
   final repository = ref.watch(necessityRepoProvider);
   return repository.list();
@@ -113,7 +113,7 @@ final necessityLabelsProvider =
 
 final necessityMapProvider =
     FutureProvider<Map<int, necessity_repo.NecessityLabel>>((ref) async {
-  final labels = await ref.watch(necessityLabelsProvider.future);
+  final labels = await ref.watch(necessityLabelsFutureProvider.future);
   return {
     for (final label in labels) label.id: label,
   };

--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -18,7 +18,7 @@ class ReviewScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final entryState = ref.watch(entryFlowControllerProvider);
     final controller = ref.read(entryFlowControllerProvider.notifier);
-    final necessityLabelsAsync = ref.watch(necessityLabelsProvider);
+    final necessityLabelsAsync = ref.watch(necessityLabelsFutureProvider);
     final necessityLabels =
         necessityLabelsAsync.value ?? <NecessityLabel>[];
 

--- a/lib/ui/planned/planned_add_form.dart
+++ b/lib/ui/planned/planned_add_form.dart
@@ -129,7 +129,7 @@ class _PlannedAddFormState extends State<_PlannedAddForm> {
 
   @override
   Widget build(BuildContext context) {
-    final necessityLabelsAsync = widget.ref.watch(necessityLabelsProvider);
+    final necessityLabelsAsync = widget.ref.watch(necessityLabelsFutureProvider);
     final necessityLabels =
         necessityLabelsAsync.value ?? <NecessityLabel>[];
 
@@ -356,7 +356,7 @@ class _PlannedAddFormState extends State<_PlannedAddForm> {
     final amount = double.parse(amountText);
     final amountMinor = (amount * 100).round();
 
-    final labelsAsync = widget.ref.read(necessityLabelsProvider);
+    final labelsAsync = widget.ref.read(necessityLabelsFutureProvider);
     final labels = labelsAsync.value ?? <NecessityLabel>[];
     NecessityLabel? selectedLabel;
     for (final label in labels) {

--- a/lib/ui/settings/necessity_settings_screen.dart
+++ b/lib/ui/settings/necessity_settings_screen.dart
@@ -16,7 +16,7 @@ class _NecessitySettingsScreenState
     extends ConsumerState<NecessitySettingsScreen> {
   @override
   Widget build(BuildContext context) {
-    final labelsAsync = ref.watch(necessityLabelsProvider);
+    final labelsAsync = ref.watch(necessityLabelsFutureProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Критичность/Необходимость')),
@@ -108,7 +108,7 @@ class _NecessitySettingsScreenState
     if (newIndex > oldIndex) {
       newIndex -= 1;
     }
-    final labels = await ref.read(necessityLabelsProvider.future);
+    final labels = await ref.read(necessityLabelsFutureProvider.future);
     if (oldIndex < 0 || oldIndex >= labels.length) {
       return;
     }
@@ -117,7 +117,7 @@ class _NecessitySettingsScreenState
     updated.insert(newIndex, moved);
     final repo = ref.read(necessityRepoProvider);
     await repo.reorder([for (final label in updated) label.id]);
-    ref.invalidate(necessityLabelsProvider);
+    ref.invalidate(necessityLabelsFutureProvider);
   }
 
   Future<void> _archiveLabel(NecessityLabel label) async {
@@ -146,7 +146,7 @@ class _NecessitySettingsScreenState
     }
     final repo = ref.read(necessityRepoProvider);
     await repo.archive(label.id);
-    ref.invalidate(necessityLabelsProvider);
+    ref.invalidate(necessityLabelsFutureProvider);
     if (!mounted) {
       return;
     }
@@ -221,7 +221,7 @@ class _NecessitySettingsScreenState
         : colorController.text.trim();
 
     if (label == null) {
-      final labels = await ref.read(necessityLabelsProvider.future);
+      final labels = await ref.read(necessityLabelsFutureProvider.future);
       final sortOrder = labels.isEmpty ? 0 : labels.last.sortOrder + 1;
       await repo.create(name: name, color: color, sortOrder: sortOrder);
     } else {
@@ -230,6 +230,6 @@ class _NecessitySettingsScreenState
 
     nameController.dispose();
     colorController.dispose();
-    ref.invalidate(necessityLabelsProvider);
+    ref.invalidate(necessityLabelsFutureProvider);
   }
 }


### PR DESCRIPTION
## Summary
- rename the necessity labels provider to a unique identifier to avoid runtime type mismatches
- update all screens that consume the necessity labels provider to use the renamed future provider

## Testing
- not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0ffe86ee48326bdc318e3313cf693