### PR TITLE
Fix overlay forms to avoid dangling dependents

### DIFF
--- a/lib/ui/entry/category_screen.dart
+++ b/lib/ui/entry/category_screen.dart
@@ -35,14 +35,12 @@ class CategoryScreen extends ConsumerWidget {
       if (option == AddCategoryOption.group) {
         await showCategoryEditForm(
           context,
-          ref,
           type: type,
           isGroup: true,
         );
       } else {
         await showCategoryEditForm(
           context,
-          ref,
           type: type,
           isGroup: false,
         );
@@ -57,7 +55,6 @@ class CategoryScreen extends ConsumerWidget {
       if (action == CategoryAction.rename) {
         await showCategoryEditForm(
           context,
-          ref,
           type: category.type,
           isGroup: false,
           initial: category,
@@ -75,7 +72,6 @@ class CategoryScreen extends ConsumerWidget {
       if (action == CategoryAction.rename) {
         await showCategoryEditForm(
           context,
-          ref,
           type: group.type,
           isGroup: true,
           initial: group,

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -408,7 +408,6 @@ class _PlannedOverview extends StatelessWidget {
                 onPressed: () async {
                   final saved = await showAddPayoutSheet(
                     context,
-                    ref,
                     type: PayoutType.salary,
                   );
                   if (!context.mounted) {
@@ -468,7 +467,7 @@ class _PlannedOverview extends StatelessWidget {
                 error: (error, _) => Text('Ошибка: $error'),
               ),
               onTap: () =>
-                  showPlannedSheet(context, ref, type: PlannedType.income),
+                  showPlannedSheet(context, type: PlannedType.income),
             ),
             const Divider(height: 0),
             ListTile(
@@ -480,7 +479,7 @@ class _PlannedOverview extends StatelessWidget {
                 error: (error, _) => Text('Ошибка: $error'),
               ),
               onTap: () =>
-                  showPlannedSheet(context, ref, type: PlannedType.expense),
+                  showPlannedSheet(context, type: PlannedType.expense),
             ),
             const Divider(height: 0),
             ListTile(
@@ -492,7 +491,7 @@ class _PlannedOverview extends StatelessWidget {
                 error: (error, _) => Text('Ошибка: $error'),
               ),
               onTap: () =>
-                  showPlannedSheet(context, ref, type: PlannedType.saving),
+                  showPlannedSheet(context, type: PlannedType.saving),
             ),
           ],
         );

--- a/lib/ui/planned/planned_sheet.dart
+++ b/lib/ui/planned/planned_sheet.dart
@@ -9,11 +9,9 @@ import '../../utils/formatting.dart';
 import 'planned_add_form.dart';
 
 Future<void> showPlannedSheet(
-  BuildContext context,
-  WidgetRef ref, {
+  BuildContext context, {
   required PlannedType type,
 }) {
-  ref.read(isSheetOpenProvider.notifier).state = true;
   return showModalBottomSheet(
     context: context,
     isScrollControlled: true,
@@ -28,217 +26,231 @@ Future<void> showPlannedSheet(
         bottom: true,
         child: Padding(
           padding: EdgeInsets.only(bottom: 16 + bottomInset),
-          child: Consumer(
-            builder: (sheetContext, sheetRef, __) {
-              return DraggableScrollableSheet(
-                expand: false,
-                initialChildSize: 0.9,
-                maxChildSize: 0.95,
-                builder: (ctx, scroll) {
-                  final itemsAsync =
-                      sheetRef.watch(plannedItemsByTypeProvider(type));
-                  final actions = sheetRef.read(plannedActionsProvider);
-
-                  Future<void> handleLongPress(PlannedItemView item) async {
-                    final action = await showModalBottomSheet<_PlannedItemAction>(
-                      context: ctx,
-                      useSafeArea: true,
-                      clipBehavior: Clip.antiAlias,
-                      shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.vertical(
-                          top: Radius.circular(24),
-                        ),
-                      ),
-                      builder: (actionContext) {
-                        final scheme = Theme.of(actionContext).colorScheme;
-                        return SafeArea(
-                          bottom: true,
-                          child: Padding(
-                            padding: EdgeInsets.only(
-                              top: 12,
-                              left: 24,
-                              right: 24,
-                              bottom:
-                                  16 + MediaQuery.of(actionContext).viewInsets.bottom,
-                            ),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                Center(
-                                  child: Container(
-                                    width: 36,
-                                    height: 4,
-                                    decoration: BoxDecoration(
-                                      color: scheme.outlineVariant,
-                                      borderRadius: BorderRadius.circular(2),
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(height: 16),
-                                ListTile(
-                                  leading: const Icon(Icons.edit_outlined),
-                                  title: const Text('Редактировать'),
-                                  onTap: () => Navigator.of(actionContext)
-                                      .pop(_PlannedItemAction.edit),
-                                ),
-                                ListTile(
-                                  leading: const Icon(Icons.delete_outline),
-                                  title: const Text('Удалить'),
-                                  onTap: () => Navigator.of(actionContext)
-                                      .pop(_PlannedItemAction.delete),
-                                ),
-                                ListTile(
-                                  leading: const Icon(Icons.close),
-                                  title: const Text('Отмена'),
-                                  onTap: () => Navigator.of(actionContext).pop(),
-                                ),
-                              ],
-                            ),
-                          ),
-                        );
-                      },
-                    );
-
-                    if (action == _PlannedItemAction.delete) {
-                      final confirm = await showDialog<bool>(
-                        context: ctx,
-                        builder: (dialogContext) => AlertDialog(
-                          title: const Text('Удалить запись?'),
-                          content:
-                              const Text('Это действие нельзя отменить.'),
-                          actions: [
-                            TextButton(
-                              onPressed: () =>
-                                  Navigator.of(dialogContext).pop(false),
-                              child: const Text('Отмена'),
-                            ),
-                            TextButton(
-                              onPressed: () =>
-                                  Navigator.of(dialogContext).pop(true),
-                              child: const Text('Удалить'),
-                            ),
-                          ],
-                        ),
-                      );
-                      if (confirm == true) {
-                        final id = item.record.id;
-                        if (id != null) {
-                          await actions.remove(id);
-                          bumpDbTick(sheetRef);
-                        }
-                      }
-                    } else if (action == _PlannedItemAction.edit) {
-                      await showPlannedAddForm(
-                        ctx,
-                        sheetRef,
-                        type: type,
-                        initialRecord: item.record,
-                      );
-                    }
-                  }
-
-                  return Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24),
-                    child: Column(
-                      children: [
-                        Container(
-                          width: 36,
-                          height: 4,
-                          decoration: BoxDecoration(
-                            color: Theme.of(ctx).colorScheme.outlineVariant,
-                            borderRadius: BorderRadius.circular(2),
-                          ),
-                        ),
-                        const SizedBox(height: 16),
-                        _SheetHeader(
-                          type: type,
-                          onClose: () => Navigator.of(ctx).pop(),
-                        ),
-                        const SizedBox(height: 16),
-                        Expanded(
-                          child: itemsAsync.when(
-                            data: (items) {
-                              if (items.isEmpty) {
-                                return ListView(
-                                  controller: scroll,
-                                  children: [
-                                    const SizedBox(height: 48),
-                                    Center(
-                                      child: Text(
-                                        'Нет запланированных записей',
-                                        style: Theme.of(ctx)
-                                            .textTheme
-                                            .bodyMedium,
-                                      ),
-                                    ),
-                                  ],
-                                );
-                              }
-                              return ListView.separated(
-                                controller: scroll,
-                                padding: EdgeInsets.zero,
-                                itemBuilder: (context, index) {
-                                  final item = items[index];
-                                  return _PlannedItemTile(
-                                    item: item,
-                                    onToggle: (value) async {
-                                      final id = item.record.id;
-                                      if (id == null) {
-                                        return;
-                                      }
-                                      await actions.toggle(id, value ?? false);
-                                      bumpDbTick(sheetRef);
-                                    },
-                                    onLongPress: () => handleLongPress(item),
-                                  );
-                                },
-                                separatorBuilder: (_, __) =>
-                                    const SizedBox(height: 12),
-                                itemCount: items.length,
-                              );
-                            },
-                            loading: () => const Center(
-                              child: CircularProgressIndicator(),
-                            ),
-                            error: (error, _) => ListView(
-                              controller: scroll,
-                              children: [
-                                const SizedBox(height: 48),
-                                Center(
-                                  child: Text(
-                                    'Ошибка загрузки: $error',
-                                    style:
-                                        Theme.of(ctx).textTheme.bodyMedium,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 16),
-                        FilledButton.icon(
-                          onPressed: () => showPlannedAddForm(
-                            ctx,
-                            sheetRef,
-                            type: type,
-                          ),
-                          icon: const Icon(Icons.add),
-                          label: const Text('Добавить'),
-                        ),
-                      ],
-                    ),
-                  );
-                },
-              );
-            },
-          ),
+          child: _PlannedSheetContent(type: type),
         ),
       );
     },
-  ).whenComplete(() {
-    ref.read(isSheetOpenProvider.notifier).state = false;
+  );
+}
+
+class _PlannedSheetContent extends ConsumerStatefulWidget {
+  const _PlannedSheetContent({
+    required this.type,
   });
+
+  final PlannedType type;
+
+  @override
+  ConsumerState<_PlannedSheetContent> createState() =>
+      _PlannedSheetContentState();
+}
+
+class _PlannedSheetContentState extends ConsumerState<_PlannedSheetContent> {
+  @override
+  void initState() {
+    super.initState();
+    ref.read(isSheetOpenProvider.notifier).state = true;
+  }
+
+  @override
+  void dispose() {
+    ref.read(isSheetOpenProvider.notifier).state = false;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.9,
+      maxChildSize: 0.95,
+      builder: (ctx, scroll) {
+        final itemsAsync = ref.watch(plannedItemsByTypeProvider(widget.type));
+        final actions = ref.read(plannedActionsProvider);
+
+        Future<void> handleLongPress(PlannedItemView item) async {
+          final action = await showModalBottomSheet<_PlannedItemAction>(
+            context: ctx,
+            useSafeArea: true,
+            clipBehavior: Clip.antiAlias,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(24),
+              ),
+            ),
+            builder: (actionContext) {
+              final scheme = Theme.of(actionContext).colorScheme;
+              return SafeArea(
+                bottom: true,
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    top: 12,
+                    left: 24,
+                    right: 24,
+                    bottom: 16 + MediaQuery.of(actionContext).viewInsets.bottom,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Center(
+                        child: Container(
+                          width: 36,
+                          height: 4,
+                          decoration: BoxDecoration(
+                            color: scheme.outlineVariant,
+                            borderRadius: BorderRadius.circular(2),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      ListTile(
+                        leading: const Icon(Icons.edit_outlined),
+                        title: const Text('Редактировать'),
+                        onTap: () =>
+                            Navigator.of(actionContext).pop(_PlannedItemAction.edit),
+                      ),
+                      ListTile(
+                        leading: const Icon(Icons.delete_outline),
+                        title: const Text('Удалить'),
+                        onTap: () =>
+                            Navigator.of(actionContext).pop(_PlannedItemAction.delete),
+                      ),
+                      ListTile(
+                        leading: const Icon(Icons.close),
+                        title: const Text('Отмена'),
+                        onTap: () => Navigator.of(actionContext).pop(),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+
+          if (action == _PlannedItemAction.delete) {
+            final confirm = await showDialog<bool>(
+              context: ctx,
+              builder: (dialogContext) => AlertDialog(
+                title: const Text('Удалить запись?'),
+                content: const Text('Это действие нельзя отменить.'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogContext).pop(false),
+                    child: const Text('Отмена'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogContext).pop(true),
+                    child: const Text('Удалить'),
+                  ),
+                ],
+              ),
+            );
+            if (confirm == true) {
+              final id = item.record.id;
+              if (id != null) {
+                await actions.remove(id);
+                bumpDbTick(ref);
+              }
+            }
+          } else if (action == _PlannedItemAction.edit) {
+            await showPlannedAddForm(
+              ctx,
+              type: widget.type,
+              initialRecord: item.record,
+            );
+          }
+        }
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            children: [
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Theme.of(ctx).colorScheme.outlineVariant,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 16),
+              _SheetHeader(
+                type: widget.type,
+                onClose: () => Navigator.of(ctx).pop(),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: itemsAsync.when(
+                  data: (items) {
+                    if (items.isEmpty) {
+                      return ListView(
+                        controller: scroll,
+                        children: [
+                          const SizedBox(height: 48),
+                          Center(
+                            child: Text(
+                              'Нет запланированных записей',
+                              style: Theme.of(ctx).textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+                    return ListView.separated(
+                      controller: scroll,
+                      padding: EdgeInsets.zero,
+                      itemBuilder: (context, index) {
+                        final item = items[index];
+                        return _PlannedItemTile(
+                          item: item,
+                          onToggle: (value) async {
+                            final id = item.record.id;
+                            if (id == null) {
+                              return;
+                            }
+                            await actions.toggle(id, value ?? false);
+                            bumpDbTick(ref);
+                          },
+                          onLongPress: () => handleLongPress(item),
+                        );
+                      },
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemCount: items.length,
+                    );
+                  },
+                  loading: () => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                  error: (error, _) => ListView(
+                    controller: scroll,
+                    children: [
+                      const SizedBox(height: 48),
+                      Center(
+                        child: Text(
+                          'Ошибка загрузки: $error',
+                          style: Theme.of(ctx).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: () => showPlannedAddForm(
+                  ctx,
+                  type: widget.type,
+                ),
+                icon: const Icon(Icons.add),
+                label: const Text('Добавить'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
 }
 
 class _SheetHeader extends StatelessWidget {

--- a/lib/ui/settings/categories_manage_screen.dart
+++ b/lib/ui/settings/categories_manage_screen.dart
@@ -29,7 +29,6 @@ class _CategoriesManageScreenState
     }
     await showCategoryEditForm(
       context,
-      ref,
       type: _selectedType,
       isGroup: option == AddCategoryOption.group,
     );
@@ -38,7 +37,6 @@ class _CategoriesManageScreenState
   Future<void> _editCategory(Category category) {
     return showCategoryEditForm(
       context,
-      ref,
       type: category.type,
       isGroup: category.isGroup,
       initial: category,

--- a/lib/ui/settings/settings_placeholder.dart
+++ b/lib/ui/settings/settings_placeholder.dart
@@ -211,7 +211,6 @@ class _SettingsPlaceholderState extends ConsumerState<SettingsPlaceholder> {
   ) async {
     final saved = await showAddPayoutSheet(
       context,
-      ref,
       type: type,
     );
 


### PR DESCRIPTION
## Summary
- refactor the necessity label editor into a ConsumerStatefulWidget bottom sheet with local form state and safe navigation
- rebuild the payout addition sheet and planned/category overlays to avoid leaking WidgetRef, use local resources, and close only after awaited work
- update settings and home screens to use the new modal APIs and keep provider-driven state tidy

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d13a4a1f808326aaba014714b0e1e4