### PR TITLE
Avoid using disposed ref in snack callback

### DIFF
--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -7,7 +7,6 @@ import '../../data/models/category.dart' as db_models;
 import '../../data/models/transaction_record.dart';
 import '../../data/repositories/necessity_repository.dart';
 import '../../data/repositories/reason_repository.dart';
-import '../../app.dart' show scaffoldMessengerKey;
 import '../../routing/app_router.dart';
 import '../../state/app_providers.dart';
 import '../../state/db_refresh.dart';
@@ -207,19 +206,15 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
         ref.read(lastEntryKindProvider.notifier).state = operationKind;
       }
       if (kReturnToOperationsAfterSave) {
+        final entryFlowControllerNotifier =
+            ref.read(entryFlowControllerProvider.notifier);
         context.goNamed(RouteNames.operations);
         if (isQuickAddKind) {
           showAddAnotherSnackGlobal(
             seconds: 5,
-            onTap: () {
-              ref
-                  .read(entryFlowControllerProvider.notifier)
-                  .resetForQuickAdd(operationKind);
-              scaffoldMessengerKey.currentState?.clearSnackBars();
-              final targetContext = scaffoldMessengerKey.currentContext;
-              if (targetContext != null) {
-                targetContext.goNamed(RouteNames.entryAmount);
-              }
+            onTap: (ctx) {
+              entryFlowControllerNotifier.resetForQuickAdd(operationKind);
+              GoRouter.of(ctx).goNamed(RouteNames.entryAmount);
             },
           );
         }

--- a/lib/ui/widgets/add_another_snack.dart
+++ b/lib/ui/widgets/add_another_snack.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../app.dart';
 
-typedef AddAnotherTap = void Function();
+typedef AddAnotherTap = void Function(BuildContext context);
 
 void showAddAnotherSnackGlobal({
   required int seconds,
@@ -52,7 +52,7 @@ class _AddAnotherContentState extends State<_AddAnotherContent>
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return InkWell(
-      onTap: widget.onTap,
+      onTap: () => widget.onTap(context),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [


### PR DESCRIPTION
## Summary
- capture the entry flow controller notifier before leaving the review screen
- reuse the stored notifier inside the snack tap callback so it can run after the screen is disposed

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d159d2c6ec8326a0ada367c7c8c3e4