### PR TITLE
Hide add another snack on tap

### DIFF
--- a/lib/ui/widgets/add_another_snack.dart
+++ b/lib/ui/widgets/add_another_snack.dart
@@ -52,7 +52,10 @@ class _AddAnotherContentState extends State<_AddAnotherContent>
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return InkWell(
-      onTap: () => widget.onTap(context),
+      onTap: () {
+        ScaffoldMessenger.maybeOf(context)?.hideCurrentSnackBar();
+        widget.onTap(context);
+      },
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [


### PR DESCRIPTION
## Summary
- hide the "add another" snackbar immediately when the action is tapped so the form can reopen without waiting

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1611ccde08326b779b29f15773cd8