### PR TITLE
Handle close on entry amount screen

### DIFF
--- a/lib/ui/entry/amount_screen.dart
+++ b/lib/ui/entry/amount_screen.dart
@@ -51,7 +51,11 @@ class AmountScreen extends ConsumerWidget {
           icon: const Icon(Icons.close),
           onPressed: () {
             controller.reset();
-            context.pop();
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.goNamed(RouteNames.home);
+            }
           },
         ),
         title: const Text('Сумма операции'),


### PR DESCRIPTION
## Summary
- prevent navigation errors when closing the amount entry screen by checking if the router can pop
- navigate back to the home screen if there is no previous route available

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d164ec85bc83269bf34028f6d1d6e9