### PR TITLE
Remove HEX color display from necessity settings UI

### DIFF
--- a/lib/ui/settings/necessity_settings_screen.dart
+++ b/lib/ui/settings/necessity_settings_screen.dart
@@ -253,8 +253,6 @@ class _NecessitySettingsScreenState
                           : const Icon(Icons.block, size: 16),
                     ),
                     title: Text(label.name),
-                    subtitle:
-                        hasColor ? Text('Цвет: ${label.color}') : null,
                     trailing: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [


### PR DESCRIPTION
## Summary
- remove the HEX color subtitle from necessity label list items so only the swatch remains
- keep the color picker UI focused on the visual swatch without any hex text output

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c6c1f3883269cf461d045b861f2