### PR TITLE
Delay sheet open flag update until after first frame

### DIFF
--- a/lib/ui/planned/planned_sheet.dart
+++ b/lib/ui/planned/planned_sheet.dart
@@ -6,6 +6,7 @@ import '../../state/app_providers.dart';
 import '../../state/planned_providers.dart';
 import '../../state/db_refresh.dart';
 import '../../utils/formatting.dart';
+import '../../utils/ref_postframe.dart';
 import 'planned_add_form.dart';
 
 Future<void> showPlannedSheet(
@@ -49,7 +50,9 @@ class _PlannedSheetContentState extends ConsumerState<_PlannedSheetContent> {
   @override
   void initState() {
     super.initState();
-    ref.read(isSheetOpenProvider.notifier).state = true;
+    ref.postFrame(() {
+      ref.read(isSheetOpenProvider.notifier).state = true;
+    });
   }
 
   @override

--- a/lib/utils/ref_postframe.dart
+++ b/lib/utils/ref_postframe.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension RefPostFrame on WidgetRef {
+  void postFrame(void Function() fn) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) fn();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a WidgetRef.postFrame helper to safely schedule provider updates after the first frame
- defer the Planned sheet open-flag provider mutation to the post-frame callback to avoid lifecycle exceptions

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68d17f25bba88326bc7b10a0a9191408