### PR TITLE
Fix post frame callback mounted check

### DIFF
--- a/lib/utils/ref_postframe.dart
+++ b/lib/utils/ref_postframe.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 extension RefPostFrame on WidgetRef {
   void postFrame(void Function() fn) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) fn();
+      if (context.mounted) fn();
     });
   }
 }


### PR DESCRIPTION
## Summary
- update WidgetRef post-frame helper to verify the build context is mounted before invoking the callback

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1803145408326878876afb0257558