### PR TITLE
Add planned master data layer and period providers

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -5,7 +5,7 @@ class AppMigrations {
   AppMigrations._();
 
   /// Latest schema version supported by the application.
-  static const int latestVersion = 5;
+  static const int latestVersion = 6;
 
   static final Map<int, List<String>> _migrationScripts = {
     1: [
@@ -83,6 +83,21 @@ class AppMigrations {
     5: [
       'ALTER TABLE transactions ADD COLUMN payout_id INTEGER NULL',
       'CREATE INDEX IF NOT EXISTS idx_transactions_payout_id ON transactions(payout_id)',
+    ],
+    6: [
+      'CREATE TABLE IF NOT EXISTS planned_master ('
+          'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+          "type TEXT CHECK(type IN ('expense','income','saving')) NOT NULL, "
+          'title TEXT NOT NULL, '
+          'default_amount_minor INTEGER NULL, '
+          'category_id INTEGER NULL, '
+          'note TEXT NULL, '
+          'archived INTEGER NOT NULL DEFAULT 0, '
+          "created_at TEXT NOT NULL DEFAULT (datetime('now')), "
+          "updated_at TEXT NOT NULL DEFAULT (datetime('now'))"
+          ')',
+      'ALTER TABLE transactions ADD COLUMN planned_id INTEGER NULL',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_planned_id ON transactions(planned_id)',
     ],
   };
 

--- a/lib/data/models/transaction_record.dart
+++ b/lib/data/models/transaction_record.dart
@@ -12,6 +12,7 @@ class TransactionRecord {
     required this.date,
     this.time,
     this.note,
+    this.plannedId,
     this.isPlanned = false,
     this.includedInPeriod = true,
     this.tags = const <String>[],
@@ -30,6 +31,7 @@ class TransactionRecord {
   final DateTime date;
   final String? time;
   final String? note;
+  final int? plannedId;
   final bool isPlanned;
   final bool includedInPeriod;
   final List<String> tags;
@@ -48,6 +50,7 @@ class TransactionRecord {
     DateTime? date,
     String? time,
     String? note,
+    Object? plannedId = _unset,
     bool? isPlanned,
     bool? includedInPeriod,
     List<String>? tags,
@@ -66,6 +69,8 @@ class TransactionRecord {
       date: date ?? this.date,
       time: time ?? this.time,
       note: note ?? this.note,
+      plannedId:
+          plannedId == _unset ? this.plannedId : plannedId as int?,
       isPlanned: isPlanned ?? this.isPlanned,
       includedInPeriod: includedInPeriod ?? this.includedInPeriod,
       tags: tags ?? this.tags,
@@ -94,6 +99,7 @@ class TransactionRecord {
       date: _parseDate(map['date'] as String?),
       time: map['time'] as String?,
       note: map['note'] as String?,
+      plannedId: map['planned_id'] as int?,
       isPlanned: (map['is_planned'] as int? ?? 0) != 0,
       includedInPeriod: (map['included_in_period'] as int? ?? 0) != 0,
       tags: _decodeTags(map['tags'] as String?),
@@ -115,6 +121,7 @@ class TransactionRecord {
       'date': _formatDate(date),
       'time': time,
       'note': note,
+      'planned_id': plannedId,
       'is_planned': isPlanned ? 1 : 0,
       'included_in_period': includedInPeriod ? 1 : 0,
       'tags': tags.isEmpty ? null : jsonEncode(tags),

--- a/lib/data/repositories/planned_master_repository.dart
+++ b/lib/data/repositories/planned_master_repository.dart
@@ -1,0 +1,254 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+
+class PlannedMaster {
+  const PlannedMaster({
+    this.id,
+    required this.type,
+    required this.title,
+    this.defaultAmountMinor,
+    this.categoryId,
+    this.note,
+    this.archived = false,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final int? id;
+  final String type;
+  final String title;
+  final int? defaultAmountMinor;
+  final int? categoryId;
+  final String? note;
+  final bool archived;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  PlannedMaster copyWith({
+    int? id,
+    String? type,
+    String? title,
+    Object? defaultAmountMinor = _sentinel,
+    Object? categoryId = _sentinel,
+    Object? note = _sentinel,
+    bool? archived,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return PlannedMaster(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      title: title ?? this.title,
+      defaultAmountMinor: defaultAmountMinor == _sentinel
+          ? this.defaultAmountMinor
+          : defaultAmountMinor as int?,
+      categoryId: categoryId == _sentinel ? this.categoryId : categoryId as int?,
+      note: note == _sentinel ? this.note : note as String?,
+      archived: archived ?? this.archived,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  factory PlannedMaster.fromMap(Map<String, Object?> map) {
+    return PlannedMaster(
+      id: map['id'] as int?,
+      type: (map['type'] as String? ?? '').toLowerCase(),
+      title: map['title'] as String? ?? '',
+      defaultAmountMinor: map['default_amount_minor'] as int?,
+      categoryId: map['category_id'] as int?,
+      note: map['note'] as String?,
+      archived: (map['archived'] as int? ?? 0) != 0,
+      createdAt: _parseDateTime(map['created_at'] as String?),
+      updatedAt: _parseDateTime(map['updated_at'] as String?),
+    );
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'id': id,
+      'type': type,
+      'title': title,
+      'default_amount_minor': defaultAmountMinor,
+      'category_id': categoryId,
+      'note': note,
+      'archived': archived ? 1 : 0,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+    };
+  }
+
+  static const Object _sentinel = Object();
+
+  static DateTime _parseDateTime(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal();
+    }
+    return DateTime.tryParse(raw) ??
+        DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal();
+  }
+}
+
+const Object _updateOptional = Object();
+
+abstract class PlannedMasterRepository {
+  Future<List<PlannedMaster>> list({bool includeArchived = false});
+
+  Future<PlannedMaster?> getById(int id);
+
+  Future<int> create({
+    required String type,
+    required String title,
+    int? defaultAmountMinor,
+    int? categoryId,
+    String? note,
+  });
+
+  Future<void> update(
+    int id, {
+    String? type,
+    String? title,
+    Object? defaultAmountMinor = _updateOptional,
+    Object? categoryId = _updateOptional,
+    Object? note = _updateOptional,
+    bool? archived,
+  });
+
+  Future<void> delete(int id);
+}
+
+class SqlitePlannedMasterRepository implements PlannedMasterRepository {
+  SqlitePlannedMasterRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  final AppDatabase _database;
+
+  static const Object _sentinel = Object();
+  static const Set<String> _allowedTypes = {'expense', 'income', 'saving'};
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<int> create({
+    required String type,
+    required String title,
+    int? defaultAmountMinor,
+    int? categoryId,
+    String? note,
+  }) async {
+    final db = await _db;
+    final normalizedType = _normalizeType(type);
+    final values = <String, Object?>{
+      'type': normalizedType,
+      'title': title,
+      'default_amount_minor': defaultAmountMinor,
+      'category_id': categoryId,
+      'note': note,
+    };
+    return db.insert('planned_master', values);
+  }
+
+  @override
+  Future<void> delete(int id) async {
+    final db = await _db;
+    final linked = await db.rawQuery(
+      'SELECT COUNT(*) AS cnt FROM transactions WHERE planned_id = ?',
+      [id],
+    );
+    final count = linked.isNotEmpty ? _readInt(linked.first['cnt']) : 0;
+    if (count > 0) {
+      throw StateError('Cannot delete planned master with existing instances');
+    }
+    await db.delete('planned_master', where: 'id = ?', whereArgs: [id]);
+  }
+
+  @override
+  Future<PlannedMaster?> getById(int id) async {
+    final db = await _db;
+    final rows = await db.query(
+      'planned_master',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return PlannedMaster.fromMap(rows.first);
+  }
+
+  @override
+  Future<List<PlannedMaster>> list({bool includeArchived = false}) async {
+    final db = await _db;
+    final rows = await db.query(
+      'planned_master',
+      where: includeArchived ? null : 'archived = 0',
+      orderBy: 'archived ASC, title COLLATE NOCASE ASC, id ASC',
+    );
+    return rows.map(PlannedMaster.fromMap).toList();
+  }
+
+  @override
+  Future<void> update(
+    int id, {
+    String? type,
+    String? title,
+    Object? defaultAmountMinor = _updateOptional,
+    Object? categoryId = _updateOptional,
+    Object? note = _updateOptional,
+    bool? archived,
+  }) async {
+    final db = await _db;
+    final values = <String, Object?>{};
+    if (type != null) {
+      values['type'] = _normalizeType(type);
+    }
+    if (title != null) {
+      values['title'] = title;
+    }
+    if (defaultAmountMinor != _updateOptional) {
+      values['default_amount_minor'] = defaultAmountMinor as int?;
+    }
+    if (categoryId != _updateOptional) {
+      values['category_id'] = categoryId as int?;
+    }
+    if (note != _updateOptional) {
+      values['note'] = note as String?;
+    }
+    if (archived != null) {
+      values['archived'] = archived ? 1 : 0;
+    }
+    if (values.isEmpty) {
+      return;
+    }
+    values['updated_at'] = DateTime.now().toUtc().toIso8601String();
+    await db.update(
+      'planned_master',
+      values,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  String _normalizeType(String type) {
+    final normalized = type.toLowerCase();
+    if (!_allowedTypes.contains(normalized)) {
+      throw ArgumentError.value(type, 'type', 'Unsupported planned type');
+    }
+    return normalized;
+  }
+
+  int _readInt(Object? value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    if (value is String) {
+      return int.tryParse(value) ?? 0;
+    }
+    return 0;
+  }
+}

--- a/lib/state/planned_master_providers.dart
+++ b/lib/state/planned_master_providers.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/repositories/planned_master_repository.dart';
+import '../data/repositories/transactions_repository.dart';
+import 'app_providers.dart';
+import 'budget_providers.dart';
+import 'db_refresh.dart';
+
+final plannedMasterRepoProvider = Provider<PlannedMasterRepository>((ref) {
+  final database = ref.watch(appDatabaseProvider);
+  return SqlitePlannedMasterRepository(database: database);
+});
+
+final plannedMasterListProvider =
+    FutureProvider<List<PlannedMaster>>((ref) async {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(plannedMasterRepoProvider);
+  return repository.list();
+});
+
+final plannedInstancesForSelectedPeriodProvider =
+    FutureProvider.family<List<TransactionItem>, String?>((ref, type) async {
+  ref.watch(dbTickProvider);
+  final bounds = ref.watch(periodBoundsProvider);
+  final repository = ref.watch(transactionsRepoProvider);
+  return repository.listPlannedByPeriod(
+    start: bounds.$1,
+    endExclusive: bounds.$2,
+    type: type,
+  );
+});
+
+final plannedIncludedForSelectedPeriodProvider =
+    FutureProvider.family<List<TransactionItem>, String?>((ref, type) async {
+  ref.watch(dbTickProvider);
+  final bounds = ref.watch(periodBoundsProvider);
+  final repository = ref.watch(transactionsRepoProvider);
+  return repository.listPlannedByPeriod(
+    start: bounds.$1,
+    endExclusive: bounds.$2,
+    type: type,
+    onlyIncluded: true,
+  );
+});


### PR DESCRIPTION
## Summary
- add schema migration v6 for planned master table and planned transaction linkage
- introduce planned master repository with SQLite implementation and extend transactions repository for planned instances
- add Riverpod providers to expose planned masters and period-specific planned transactions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d39d59589483268e2574d3c38b61ab