### PR TITLE
Implement planned master library and period assignment flows

### DIFF
--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -14,6 +14,8 @@ import '../ui/home/home_screen.dart';
 import '../ui/operations/operations_screen.dart';
 import '../ui/planned/planned_expense_stub.dart';
 import '../ui/planned/planned_income_stub.dart';
+import '../ui/planned/planned_library_screen.dart';
+import '../ui/planned/planned_master_detail_screen.dart';
 import '../ui/planned/planned_savings_stub.dart';
 import '../ui/settings/settings_placeholder.dart';
 
@@ -93,6 +95,33 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const PlannedSavingsStub(),
       ),
       GoRoute(
+        path: '/planned/library',
+        name: RouteNames.plannedLibrary,
+        builder: (context, state) {
+          final select = state.uri.queryParameters['select'] == '1';
+          return PlannedLibraryScreen(selectForAssignment: select);
+        },
+      ),
+      GoRoute(
+        path: '/planned/master/:id',
+        name: RouteNames.plannedMasterDetail,
+        builder: (context, state) {
+          final idRaw = state.pathParameters['id'];
+          final masterId = int.tryParse(idRaw ?? '');
+          if (masterId == null) {
+            return const Scaffold(
+              body: Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Text('Некорректный идентификатор плана'),
+                ),
+              ),
+            );
+          }
+          return PlannedMasterDetailScreen(masterId: masterId);
+        },
+      ),
+      GoRoute(
         path: '/accounts',
         name: RouteNames.accounts,
         builder: (context, state) => const AccountsListStub(),
@@ -141,6 +170,8 @@ class RouteNames {
   static const String plannedIncome = 'planned-income';
   static const String plannedExpense = 'planned-expense';
   static const String plannedSavings = 'planned-savings';
+  static const String plannedLibrary = 'planned-library';
+  static const String plannedMasterDetail = 'planned-master-detail';
   static const String accounts = 'accounts';
   static const String accountCreate = 'account-create';
   static const String accountEdit = 'account-edit';

--- a/lib/state/planned_master_providers.dart
+++ b/lib/state/planned_master_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../data/models/category.dart' as category_models;
 import '../data/repositories/planned_master_repository.dart';
 import '../data/repositories/transactions_repository.dart';
 import 'app_providers.dart';
@@ -9,6 +10,13 @@ import 'db_refresh.dart';
 final plannedMasterRepoProvider = Provider<PlannedMasterRepository>((ref) {
   final database = ref.watch(appDatabaseProvider);
   return SqlitePlannedMasterRepository(database: database);
+});
+
+final plannedMasterByIdProvider =
+    FutureProvider.family<PlannedMaster?, int>((ref, id) async {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(plannedMasterRepoProvider);
+  return repository.getById(id);
 });
 
 final plannedMasterListProvider =
@@ -41,4 +49,31 @@ final plannedIncludedForSelectedPeriodProvider =
     type: type,
     onlyIncluded: true,
   );
+});
+
+final plannedInstancesCountByMasterProvider =
+    FutureProvider<Map<int, int>>((ref) async {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(transactionsRepoProvider);
+  final records = await repository.listPlanned();
+  final result = <int, int>{};
+  for (final record in records) {
+    final masterId = record.plannedId;
+    if (masterId == null) {
+      continue;
+    }
+    result[masterId] = (result[masterId] ?? 0) + 1;
+  }
+  return result;
+});
+
+final categoriesMapProvider = FutureProvider<
+    Map<int, category_models.Category>>((ref) async {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(categoriesRepositoryProvider);
+  final categories = await repository.getAll();
+  return {
+    for (final category in categories)
+      if (category.id != null) category.id!: category,
+  };
 });

--- a/lib/ui/planned/planned_assign_to_period_sheet.dart
+++ b/lib/ui/planned/planned_assign_to_period_sheet.dart
@@ -1,0 +1,473 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/account.dart';
+import '../../data/models/category.dart';
+import '../../data/models/transaction_record.dart';
+import '../../data/repositories/planned_master_repository.dart';
+import '../../data/repositories/necessity_repository.dart' as necessity_repo;
+import '../../state/app_providers.dart';
+import '../../state/budget_providers.dart';
+import '../../state/db_refresh.dart';
+import '../../state/planned_master_providers.dart';
+import '../../utils/formatting.dart';
+
+Future<bool?> showPlannedAssignToPeriodSheet(
+  BuildContext context, {
+  required PlannedMaster master,
+  TransactionRecord? initial,
+}) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+    ),
+    builder: (modalContext) {
+      return Padding(
+        padding: EdgeInsets.only(
+          left: 24,
+          right: 24,
+          top: 16,
+          bottom: 16 + MediaQuery.of(modalContext).viewInsets.bottom,
+        ),
+        child: _PlannedAssignToPeriodForm(
+          master: master,
+          initial: initial,
+        ),
+      );
+    },
+  );
+}
+
+class _PlannedAssignToPeriodForm extends ConsumerStatefulWidget {
+  const _PlannedAssignToPeriodForm({
+    required this.master,
+    this.initial,
+  });
+
+  final PlannedMaster master;
+  final TransactionRecord? initial;
+
+  @override
+  ConsumerState<_PlannedAssignToPeriodForm> createState() =>
+      _PlannedAssignToPeriodFormState();
+}
+
+class _PlannedAssignToPeriodFormState
+    extends ConsumerState<_PlannedAssignToPeriodForm> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _amountController;
+  late DateTime _selectedDate;
+  int? _categoryId;
+  int? _accountId;
+  int? _necessityId;
+  bool _included = false;
+  bool _isSaving = false;
+  bool _accountInitialized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initial;
+    final master = widget.master;
+    final bounds = ref.read(periodBoundsProvider);
+    final defaultDate = _clampDate(initial?.date ?? bounds.$1, bounds.$1, bounds.$2);
+    _selectedDate = defaultDate;
+    _categoryId = initial?.categoryId ?? master.categoryId;
+    _accountId = initial?.accountId;
+    _necessityId = initial?.necessityId;
+    _included = initial?.includedInPeriod ?? false;
+    if (_accountId != null) {
+      _accountInitialized = true;
+    }
+    final amountMinor = initial?.amountMinor ?? master.defaultAmountMinor;
+    _amountController = TextEditingController(
+      text: amountMinor != null ? _formatAmount(amountMinor) : '',
+    );
+
+    ref.listen<(DateTime, DateTime)>(periodBoundsProvider, (previous, next) {
+      final start = next.$1;
+      final end = next.$2;
+      if (!mounted) {
+        return;
+      }
+      if (_selectedDate.isBefore(start) || !_selectedDate.isBefore(end)) {
+        setState(() {
+          _selectedDate = start;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final master = widget.master;
+    final bounds = ref.watch(periodBoundsProvider);
+    final periodLabel = ref.watch(periodLabelProvider);
+    final nav = ref.watch(periodNavProvider);
+    final categoryType = _categoryTypeForType(master.type);
+    final categoriesAsync = categoryType != null
+        ? ref.watch(categoriesByTypeProvider(categoryType))
+        : const AsyncValue<List<Category>>.data(<Category>[]);
+    final accountsAsync = ref.watch(accountsDbProvider);
+    final necessityLabelsAsync = master.type == 'expense'
+        ? ref.watch(necessityLabelsFutureProvider)
+        : const AsyncValue<List<necessity_repo.NecessityLabel>>.data(
+            <necessity_repo.NecessityLabel>[],
+          );
+
+    accountsAsync.whenData((accounts) {
+      if (_accountInitialized || accounts.isEmpty) {
+        return;
+      }
+      final defaultAccount = accounts.firstWhere(
+        (acc) => acc.name.trim().toLowerCase() == 'карта',
+        orElse: () => accounts.first,
+      );
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _accountId = defaultAccount.id;
+          _accountInitialized = true;
+        });
+      });
+    });
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Назначить «${master.title}»',
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              IconButton(
+                onPressed: () {
+                  nav.prev();
+                },
+                icon: const Icon(Icons.chevron_left),
+              ),
+              Expanded(
+                child: Column(
+                  children: [
+                    const Text('Период'),
+                    Text(
+                      periodLabel,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                onPressed: () {
+                  nav.next();
+                },
+                icon: const Icon(Icons.chevron_right),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _amountController,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(
+              labelText: 'Сумма',
+              prefixText: '₽ ',
+            ),
+            validator: (value) {
+              final text = value?.trim();
+              if (text == null || text.isEmpty) {
+                return 'Введите сумму';
+              }
+              final parsed = double.tryParse(text.replaceAll(',', '.'));
+              if (parsed == null || parsed <= 0) {
+                return 'Сумма должна быть больше 0';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 12),
+          categoriesAsync.when(
+            data: (categories) {
+              if (categories.isEmpty) {
+                return const Text(
+                  'Нет доступных категорий. Добавьте их в настройках.',
+                  style: TextStyle(color: Colors.redAccent),
+                );
+              }
+              return DropdownButtonFormField<int>(
+                value: _categoryId,
+                decoration: const InputDecoration(labelText: 'Категория'),
+                items: [
+                  for (final category in categories)
+                    DropdownMenuItem<int>(
+                      value: category.id,
+                      child: Text(category.name),
+                    ),
+                ],
+                onChanged: (value) => setState(() => _categoryId = value),
+                validator: (value) => value == null ? 'Выберите категорию' : null,
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => Text('Не удалось загрузить категории: $error'),
+          ),
+          const SizedBox(height: 12),
+          if (master.type == 'expense')
+            necessityLabelsAsync.when(
+              data: (labels) {
+                if (labels.isEmpty) {
+                  return const SizedBox.shrink();
+                }
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Критичность/необходимость',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        for (final label in labels)
+                          ChoiceChip(
+                            label: Text(label.name),
+                            selected: label.id == _necessityId,
+                            onSelected: (selected) {
+                              setState(() {
+                                _necessityId = selected ? label.id : null;
+                              });
+                            },
+                          ),
+                      ],
+                    ),
+                  ],
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Text('Не удалось загрузить метки: $error'),
+            ),
+          const SizedBox(height: 12),
+          accountsAsync.when(
+            data: (accounts) {
+              if (accounts.isEmpty) {
+                return const Text('Добавьте счёт, чтобы продолжить.');
+              }
+              return DropdownButtonFormField<int>(
+                value: _accountId,
+                decoration: const InputDecoration(labelText: 'Счёт'),
+                items: [
+                  for (final account in accounts)
+                    DropdownMenuItem<int>(
+                      value: account.id,
+                      child: Text(account.name),
+                    ),
+                ],
+                onChanged: (value) => setState(() => _accountId = value),
+                validator: (value) => value == null ? 'Выберите счёт' : null,
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => Text('Не удалось загрузить счета: $error'),
+          ),
+          const SizedBox(height: 12),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: const Icon(Icons.event_outlined),
+            title: const Text('Дата'),
+            subtitle: Text(formatDate(_selectedDate)),
+            onTap: () async {
+              final picked = await showDatePicker(
+                context: context,
+                initialDate: _selectedDate,
+                firstDate: bounds.$1,
+                lastDate: bounds.$2.subtract(const Duration(days: 1)),
+              );
+              if (picked != null && mounted) {
+                setState(() => _selectedDate = picked);
+              }
+            },
+          ),
+          CheckboxListTile(
+            contentPadding: EdgeInsets.zero,
+            value: _included,
+            onChanged: (value) => setState(() => _included = value ?? false),
+            title: const Text('Показать на Главной'),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: _isSaving
+                      ? null
+                      : () => Navigator.of(context).pop(false),
+                  child: const Text('Отмена'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton(
+                  onPressed: _isSaving ? null : _submit,
+                  child: _isSaving
+                      ? const SizedBox(
+                          height: 18,
+                          width: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Сохранить'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+
+    final master = widget.master;
+    final repo = ref.read(transactionsRepoProvider);
+    final plannedId = master.id;
+    if (plannedId == null) {
+      return;
+    }
+    final amountText = _amountController.text.trim();
+    final amountMinor = (double.parse(amountText.replaceAll(',', '.')) * 100).round();
+    final categoryId = _categoryId;
+    final accountId = _accountId;
+    if (categoryId == null || accountId == null) {
+      return;
+    }
+
+    setState(() => _isSaving = true);
+    try {
+      final initial = widget.initial;
+      if (initial == null) {
+        String? necessityLabel;
+        int? necessityId;
+        if (master.type == 'expense' && _necessityId != null) {
+          final labels =
+              ref.read(necessityLabelsFutureProvider).value ?? const [];
+          for (final label in labels) {
+            if (label.id == _necessityId) {
+              necessityLabel = label.name;
+              necessityId = label.id;
+              break;
+            }
+          }
+        }
+        await repo.createPlannedInstance(
+          plannedId: plannedId,
+          type: master.type,
+          accountId: accountId,
+          amountMinor: amountMinor,
+          date: _selectedDate,
+          categoryId: categoryId,
+          necessityId: necessityId,
+          necessityLabel: necessityLabel,
+          includedInPeriod: _included,
+        );
+      } else {
+        final updated = initial.copyWith(
+          amountMinor: amountMinor,
+          categoryId: categoryId,
+          accountId: accountId,
+          date: _selectedDate,
+          includedInPeriod: _included,
+          necessityId: master.type == 'expense' ? _necessityId : null,
+          necessityLabel: master.type == 'expense'
+              ? _resolveNecessityLabel(_necessityId)
+              : null,
+        );
+        await repo.update(updated, includedInPeriod: _included);
+      }
+      if (!mounted) {
+        return;
+      }
+      bumpDbTick(ref);
+      Navigator.of(context).pop(true);
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  CategoryType? _categoryTypeForType(String type) {
+    switch (type) {
+      case 'income':
+        return CategoryType.income;
+      case 'expense':
+        return CategoryType.expense;
+      case 'saving':
+        return CategoryType.saving;
+      default:
+        return null;
+    }
+  }
+
+  DateTime _clampDate(DateTime value, DateTime start, DateTime endExclusive) {
+    if (value.isBefore(start)) {
+      return start;
+    }
+    if (!value.isBefore(endExclusive)) {
+      return endExclusive.subtract(const Duration(days: 1));
+    }
+    return value;
+  }
+
+  String _formatAmount(int amountMinor) {
+    final value = amountMinor / 100;
+    if (value == value.roundToDouble()) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toStringAsFixed(2);
+  }
+
+  String? _resolveNecessityLabel(int? id) {
+    if (id == null) {
+      return null;
+    }
+    final labels = ref.read(necessityLabelsFutureProvider).value ?? const [];
+    for (final label in labels) {
+      if (label.id == id) {
+        return label.name;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/ui/planned/planned_library_screen.dart
+++ b/lib/ui/planned/planned_library_screen.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../data/repositories/planned_master_repository.dart';
+import '../../routing/app_router.dart';
+import '../../state/db_refresh.dart';
+import '../../state/planned_master_providers.dart';
+import '../../utils/formatting.dart';
+import 'planned_assign_to_period_sheet.dart';
+import 'planned_master_edit_sheet.dart';
+
+class PlannedLibraryScreen extends ConsumerStatefulWidget {
+  const PlannedLibraryScreen({super.key, this.selectForAssignment = false});
+
+  final bool selectForAssignment;
+
+  @override
+  ConsumerState<PlannedLibraryScreen> createState() =>
+      _PlannedLibraryScreenState();
+}
+
+class _PlannedLibraryScreenState
+    extends ConsumerState<PlannedLibraryScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final mastersAsync = ref.watch(plannedMasterListProvider);
+    final counts = ref.watch(plannedInstancesCountByMasterProvider).value ?? {};
+    final categories = ref.watch(categoriesMapProvider).value ?? {};
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Общий план'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'Новый шаблон',
+            onPressed: () => showPlannedMasterEditSheet(context),
+          ),
+        ],
+      ),
+      body: mastersAsync.when(
+        data: (masters) {
+          if (masters.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'Добавьте первый шаблон, чтобы быстро назначать планы по периодам.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: masters.length,
+            separatorBuilder: (_, __) => const Divider(height: 0),
+            itemBuilder: (context, index) {
+              final master = masters[index];
+              final id = master.id;
+              final categoryName =
+                  master.categoryId != null ? categories[master.categoryId!]?.name : null;
+              final defaultAmount = master.defaultAmountMinor != null
+                  ? formatCurrencyMinor(master.defaultAmountMinor!)
+                  : null;
+              final subtitle = _buildSubtitle(categoryName, defaultAmount);
+              final hasInstances = id != null && (counts[id] ?? 0) > 0;
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: Colors.transparent,
+                  child: Icon(_iconForType(master.type)),
+                ),
+                title: Text(master.title),
+                subtitle: subtitle != null ? Text(subtitle) : null,
+                trailing: PopupMenuButton<_MasterMenuAction>(
+                  onSelected: (action) => _handleMenuAction(context, master, action,
+                      canDelete: !hasInstances),
+                  itemBuilder: (context) {
+                    final items = <PopupMenuEntry<_MasterMenuAction>>[
+                      const PopupMenuItem(
+                        value: _MasterMenuAction.edit,
+                        child: Text('Редактировать'),
+                      ),
+                      const PopupMenuItem(
+                        value: _MasterMenuAction.assign,
+                        child: Text('Назначить в период'),
+                      ),
+                      PopupMenuItem(
+                        value: _MasterMenuAction.toggleArchive,
+                        child: Text(master.archived ? 'Разархивировать' : 'Архивировать'),
+                      ),
+                    ];
+                    if (!hasInstances) {
+                      items.add(
+                        const PopupMenuItem(
+                          value: _MasterMenuAction.delete,
+                          child: Text('Удалить'),
+                        ),
+                      );
+                    }
+                    return items;
+                  },
+                ),
+                onTap: id == null
+                    ? null
+                    : () => _handleTap(context, master, canDelete: !hasInstances),
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('Не удалось загрузить список: $error'),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String? _buildSubtitle(String? categoryName, String? defaultAmount) {
+    if (categoryName == null && defaultAmount == null) {
+      return null;
+    }
+    if (categoryName != null && defaultAmount != null) {
+      return '$categoryName · $defaultAmount';
+    }
+    return categoryName ?? defaultAmount;
+  }
+
+  IconData _iconForType(String type) {
+    switch (type) {
+      case 'income':
+        return Icons.trending_up;
+      case 'saving':
+        return Icons.savings_outlined;
+      case 'expense':
+      default:
+        return Icons.shopping_bag_outlined;
+    }
+  }
+
+  Future<void> _handleTap(
+    BuildContext context,
+    PlannedMaster master, {
+    required bool canDelete,
+  }) async {
+    if (widget.selectForAssignment) {
+      final saved = await showPlannedAssignToPeriodSheet(
+        context,
+        master: master,
+      );
+      if (!mounted) {
+        return;
+      }
+      if (saved == true) {
+        Navigator.of(context).pop(master);
+      }
+      return;
+    }
+    final id = master.id;
+    if (id == null) {
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    context.pushNamed(
+      RouteNames.plannedMasterDetail,
+      pathParameters: {'id': id.toString()},
+    );
+  }
+
+  Future<void> _handleMenuAction(
+    BuildContext context,
+    PlannedMaster master,
+    _MasterMenuAction action, {
+    required bool canDelete,
+  }) async {
+    switch (action) {
+      case _MasterMenuAction.edit:
+        await showPlannedMasterEditSheet(context, initial: master);
+        break;
+      case _MasterMenuAction.assign:
+        await showPlannedAssignToPeriodSheet(context, master: master);
+        break;
+      case _MasterMenuAction.toggleArchive:
+        await _toggleArchive(context, master);
+        break;
+      case _MasterMenuAction.delete:
+        if (canDelete) {
+          await _deleteMaster(context, master);
+        }
+        break;
+    }
+  }
+
+  Future<void> _toggleArchive(BuildContext context, PlannedMaster master) async {
+    final id = master.id;
+    if (id == null) {
+      return;
+    }
+    final repo = ref.read(plannedMasterRepoProvider);
+    await repo.update(id, archived: !master.archived);
+    if (!mounted) {
+      return;
+    }
+    bumpDbTick(ref);
+  }
+
+  Future<void> _deleteMaster(BuildContext context, PlannedMaster master) async {
+    final id = master.id;
+    if (id == null) {
+      return;
+    }
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Удалить шаблон?'),
+        content: const Text('Это действие нельзя отменить.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) {
+      return;
+    }
+    final repo = ref.read(plannedMasterRepoProvider);
+    try {
+      await repo.delete(id);
+      if (!mounted) {
+        return;
+      }
+      bumpDbTick(ref);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Шаблон удалён')),
+      );
+    } on StateError catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.message)),
+      );
+    }
+  }
+}
+
+enum _MasterMenuAction { edit, assign, toggleArchive, delete }

--- a/lib/ui/planned/planned_master_detail_screen.dart
+++ b/lib/ui/planned/planned_master_detail_screen.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/transaction_record.dart';
+import '../../data/repositories/planned_master_repository.dart';
+import '../../state/budget_providers.dart';
+import '../../state/db_refresh.dart';
+import '../../state/planned_master_providers.dart';
+import '../../state/app_providers.dart';
+import '../../utils/formatting.dart';
+import 'planned_assign_to_period_sheet.dart';
+import 'planned_master_edit_sheet.dart';
+
+class PlannedMasterDetailScreen extends ConsumerStatefulWidget {
+  const PlannedMasterDetailScreen({super.key, required this.masterId});
+
+  final int masterId;
+
+  @override
+  ConsumerState<PlannedMasterDetailScreen> createState() =>
+      _PlannedMasterDetailScreenState();
+}
+
+class _PlannedMasterDetailScreenState
+    extends ConsumerState<PlannedMasterDetailScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final masterAsync = ref.watch(plannedMasterByIdProvider(widget.masterId));
+    final periodLabel = ref.watch(periodLabelProvider);
+    final bounds = ref.watch(periodBoundsProvider);
+    final categoriesMap = ref.watch(categoriesMapProvider).value ?? {};
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Детали плана'),
+      ),
+      body: masterAsync.when(
+        data: (master) {
+          if (master == null) {
+            return const Center(child: Text('Шаблон не найден'));
+          }
+          final categoryName = master.categoryId != null
+              ? categoriesMap[master.categoryId!]?.name
+              : null;
+          final instancesAsync =
+              ref.watch(plannedInstancesForSelectedPeriodProvider(master.type));
+          return RefreshIndicator(
+            onRefresh: () async {
+              bumpDbTick(ref);
+            },
+            child: ListView(
+              padding: const EdgeInsets.all(24),
+              children: [
+                _MasterHeader(
+                  master: master,
+                  categoryName: categoryName,
+                  onEdit: () {
+                    showPlannedMasterEditSheet(
+                      context,
+                      initial: master,
+                    );
+                  },
+                  onAssign: () {
+                    showPlannedAssignToPeriodSheet(
+                      context,
+                      master: master,
+                    );
+                  },
+                  onToggleArchive: () {
+                    _toggleArchive(master);
+                  },
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Экземпляры ($periodLabel)',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 12),
+                instancesAsync.when(
+                  data: (items) {
+                    final filtered = items
+                        .where((item) => item.plannedId == master.id)
+                        .toList();
+                    if (filtered.isEmpty) {
+                      return const Text(
+                        'В выбранном периоде нет экземпляров. Назначьте шаблон, чтобы он появился здесь.',
+                      );
+                    }
+                    return Column(
+                      children: [
+                        for (final item in filtered)
+                          _InstanceTile(
+                            record: item,
+                            periodLabel: periodBadge(bounds.$1, bounds.$2),
+                            onToggle: (value) => _toggleIncluded(item, value),
+                            onEdit: () => showPlannedAssignToPeriodSheet(
+                              context,
+                              master: master,
+                              initial: item,
+                            ),
+                            onDelete: () => _deleteInstance(item),
+                          ),
+                      ],
+                    );
+                  },
+                  loading: () => const Center(child: CircularProgressIndicator()),
+                  error: (error, _) => Text('Ошибка: $error'),
+                ),
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('Ошибка: $error')),
+      ),
+    );
+  }
+
+  Future<void> _toggleArchive(PlannedMaster master) async {
+    final id = master.id;
+    if (id == null) {
+      return;
+    }
+    final repo = ref.read(plannedMasterRepoProvider);
+    await repo.update(id, archived: !master.archived);
+    if (!mounted) {
+      return;
+    }
+    bumpDbTick(ref);
+  }
+
+  Future<void> _toggleIncluded(TransactionRecord record, bool value) async {
+    final id = record.id;
+    if (id == null) {
+      return;
+    }
+    final repo = ref.read(transactionsRepoProvider);
+    await repo.setIncludedInPeriod(transactionId: id, value: value);
+    if (!mounted) {
+      return;
+    }
+    bumpDbTick(ref);
+  }
+
+  Future<void> _deleteInstance(TransactionRecord record) async {
+    final id = record.id;
+    if (id == null) {
+      return;
+    }
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Удалить экземпляр?'),
+        content: const Text('Это действие нельзя отменить.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) {
+      return;
+    }
+    final repo = ref.read(transactionsRepoProvider);
+    await repo.delete(id);
+    if (!mounted) {
+      return;
+    }
+    bumpDbTick(ref);
+  }
+}
+
+class _MasterHeader extends StatelessWidget {
+  const _MasterHeader({
+    required this.master,
+    required this.categoryName,
+    required this.onEdit,
+    required this.onAssign,
+    required this.onToggleArchive,
+  });
+
+  final PlannedMaster master;
+  final String? categoryName;
+  final VoidCallback onEdit;
+  final VoidCallback onAssign;
+  final VoidCallback onToggleArchive;
+
+  @override
+  Widget build(BuildContext context) {
+    final amount = master.defaultAmountMinor;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Chip(label: Text(_typeLabel(master.type))),
+                const SizedBox(width: 8),
+                if (master.archived)
+                  const Chip(
+                    avatar: Icon(Icons.archive_outlined, size: 16),
+                    label: Text('В архиве'),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              master.title,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            if (categoryName != null) ...[
+              const SizedBox(height: 8),
+              Text('Категория: $categoryName'),
+            ],
+            if (amount != null) ...[
+              const SizedBox(height: 8),
+              Text('Сумма по умолчанию: ${formatCurrencyMinor(amount)}'),
+            ],
+            if (master.note != null && master.note!.trim().isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text('Примечание: ${master.note}'),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                FilledButton.icon(
+                  onPressed: onEdit,
+                  icon: const Icon(Icons.edit_outlined),
+                  label: const Text('Редактировать'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: onAssign,
+                  icon: const Icon(Icons.event_available_outlined),
+                  label: const Text('Назначить в период'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onToggleArchive,
+                  icon: Icon(master.archived
+                      ? Icons.unarchive_outlined
+                      : Icons.archive_outlined),
+                  label: Text(master.archived ? 'Разархивировать' : 'Архивировать'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _typeLabel(String type) {
+    switch (type) {
+      case 'income':
+        return 'Доход';
+      case 'saving':
+        return 'Сбережение';
+      case 'expense':
+      default:
+        return 'Расход';
+    }
+  }
+}
+
+class _InstanceTile extends StatelessWidget {
+  const _InstanceTile({
+    required this.record,
+    required this.periodLabel,
+    required this.onToggle,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final TransactionRecord record;
+  final String periodLabel;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Chip(label: Text(periodLabel)),
+                const Spacer(),
+                Checkbox(
+                  value: record.includedInPeriod,
+                  onChanged: (value) {
+                    if (value != null) {
+                      onToggle(value);
+                    }
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              formatCurrencyMinor(record.amountMinor),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                TextButton.icon(
+                  onPressed: onEdit,
+                  icon: const Icon(Icons.edit_outlined),
+                  label: const Text('Изменить'),
+                ),
+                const SizedBox(width: 12),
+                TextButton.icon(
+                  onPressed: onDelete,
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Удалить'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String periodBadge(DateTime start, DateTime endEx) {
+  const m = [
+    'янв',
+    'фев',
+    'мар',
+    'апр',
+    'май',
+    'июн',
+    'июл',
+    'авг',
+    'сен',
+    'окт',
+    'ноя',
+    'дек'
+  ];
+  final month = m[start.month - 1];
+  final to = endEx.subtract(const Duration(days: 1)).day;
+  return '$month ${start.day}–$to';
+}

--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/category.dart';
+import '../../data/repositories/planned_master_repository.dart';
+import '../../state/app_providers.dart';
+import '../../state/db_refresh.dart';
+import '../../state/planned_master_providers.dart';
+
+Future<void> showPlannedMasterEditSheet(
+  BuildContext context, {
+  PlannedMaster? initial,
+}) {
+  return showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+    ),
+    builder: (modalContext) {
+      return Padding(
+        padding: EdgeInsets.only(
+          left: 24,
+          right: 24,
+          top: 16,
+          bottom: 16 + MediaQuery.of(modalContext).viewInsets.bottom,
+        ),
+        child: _PlannedMasterEditForm(initial: initial),
+      );
+    },
+  );
+}
+
+class _PlannedMasterEditForm extends ConsumerStatefulWidget {
+  const _PlannedMasterEditForm({this.initial});
+
+  final PlannedMaster? initial;
+
+  @override
+  ConsumerState<_PlannedMasterEditForm> createState() =>
+      _PlannedMasterEditFormState();
+}
+
+class _PlannedMasterEditFormState
+    extends ConsumerState<_PlannedMasterEditForm> {
+  late final TextEditingController _titleController;
+  late final TextEditingController _amountController;
+  late final TextEditingController _noteController;
+  final _formKey = GlobalKey<FormState>();
+
+  String _type = 'expense';
+  int? _categoryId;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initial;
+    _type = initial?.type ?? 'expense';
+    _categoryId = initial?.categoryId;
+    _titleController = TextEditingController(text: initial?.title ?? '');
+    _noteController = TextEditingController(text: initial?.note ?? '');
+    _amountController = TextEditingController(
+      text: initial?.defaultAmountMinor != null
+          ? _formatAmount(initial!.defaultAmountMinor!)
+          : '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _amountController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final categoryType = _categoryTypeForType(_type);
+    final categoriesAsync = categoryType != null
+        ? ref.watch(categoriesByTypeProvider(categoryType))
+        : const AsyncValue<List<Category>>.data(<Category>[]);
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            widget.initial == null ? 'Новый шаблон' : 'Редактирование шаблона',
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          SegmentedButton<String>(
+            segments: const [
+              ButtonSegment(value: 'expense', label: Text('Расход')),
+              ButtonSegment(value: 'income', label: Text('Доход')),
+              ButtonSegment(value: 'saving', label: Text('Сбережение')),
+            ],
+            selected: {_type},
+            onSelectionChanged: (values) {
+              if (values.isEmpty) {
+                return;
+              }
+              setState(() {
+                _type = values.first;
+                _categoryId = null;
+              });
+            },
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _titleController,
+            decoration: const InputDecoration(labelText: 'Название'),
+            validator: (value) {
+              if (value == null || value.trim().isEmpty) {
+                return 'Введите название';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 12),
+          categoriesAsync.when(
+            data: (categories) {
+              if (categories.isEmpty) {
+                return const SizedBox.shrink();
+              }
+              return DropdownButtonFormField<int?>(
+                value: _categoryId,
+                decoration: const InputDecoration(labelText: 'Категория (опц.)'),
+                items: [
+                  const DropdownMenuItem<int?>(
+                    value: null,
+                    child: Text('Без категории'),
+                  ),
+                  for (final category in categories)
+                    DropdownMenuItem<int?>(
+                      value: category.id,
+                      child: Text(category.name),
+                    ),
+                ],
+                onChanged: (value) => setState(() => _categoryId = value),
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => Text('Не удалось загрузить категории: $error'),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _amountController,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(
+              labelText: 'Сумма по умолчанию (опц.)',
+              prefixText: '₽ ',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _noteController,
+            decoration: const InputDecoration(labelText: 'Примечание'),
+            maxLines: 3,
+          ),
+          const SizedBox(height: 20),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: _isSaving
+                      ? null
+                      : () => Navigator.of(context).pop(),
+                  child: const Text('Отмена'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton(
+                  onPressed: _isSaving ? null : _submit,
+                  child: _isSaving
+                      ? const SizedBox(
+                          height: 18,
+                          width: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Сохранить'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+    final repo = ref.read(plannedMasterRepoProvider);
+    final title = _titleController.text.trim();
+    final note = _noteController.text.trim().isEmpty
+        ? null
+        : _noteController.text.trim();
+    final amountText = _amountController.text.trim();
+    final amountMinor = amountText.isEmpty
+        ? null
+        : (_parseAmount(amountText) * 100).round();
+
+    setState(() => _isSaving = true);
+    try {
+      final initial = widget.initial;
+      if (initial == null) {
+        await repo.create(
+          type: _type,
+          title: title,
+          defaultAmountMinor: amountMinor,
+          categoryId: _categoryId,
+          note: note,
+        );
+      } else {
+        final id = initial.id;
+        if (id != null) {
+          await repo.update(
+            id,
+            type: _type,
+            title: title,
+            defaultAmountMinor: amountMinor,
+            categoryId: _categoryId,
+            note: note,
+          );
+        }
+      }
+      if (!mounted) {
+        return;
+      }
+      bumpDbTick(ref);
+      Navigator.of(context).pop();
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  CategoryType? _categoryTypeForType(String type) {
+    switch (type) {
+      case 'income':
+        return CategoryType.income;
+      case 'expense':
+        return CategoryType.expense;
+      case 'saving':
+        return CategoryType.saving;
+      default:
+        return null;
+    }
+  }
+
+  String _formatAmount(int amountMinor) {
+    final value = amountMinor / 100;
+    if (value == value.roundToDouble()) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toStringAsFixed(2);
+  }
+
+  double _parseAmount(String text) {
+    final normalized = text.replaceAll(',', '.');
+    return double.tryParse(normalized) ?? 0;
+  }
+}

--- a/lib/ui/settings/settings_placeholder.dart
+++ b/lib/ui/settings/settings_placeholder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../data/models/payout.dart';
 import '../../state/app_providers.dart';
@@ -11,6 +12,7 @@ import 'categories_manage_screen.dart';
 import 'necessity_settings_screen.dart';
 import 'reasons_settings_screen.dart';
 import '../home/daily_limit_sheet.dart';
+import '../../routing/app_router.dart';
 
 class SettingsPlaceholder extends ConsumerStatefulWidget {
   const SettingsPlaceholder({super.key});
@@ -244,6 +246,12 @@ class _SettingsPlaceholderState extends ConsumerState<SettingsPlaceholder> {
                       ),
                     );
                   },
+                ),
+                const Divider(height: 0),
+                ListTile(
+                  title: const Text('Общий план'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => context.pushNamed(RouteNames.plannedLibrary),
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- add planned library screen with create/edit/archive actions and period assignment shortcuts
- implement detailed master view with instance management and assign/edit/delete options
- integrate new bottom sheets for master editing and assigning instances to periods
- update planned overview to use selected period data, add entry point from settings, and wire up new navigation routes

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3a2228c2c832689e7739719d98661