### PR TITLE
Fix period assignment listener usage

### DIFF
--- a/lib/ui/planned/planned_assign_to_period_sheet.dart
+++ b/lib/ui/planned/planned_assign_to_period_sheet.dart
@@ -87,6 +87,17 @@ class _PlannedAssignToPeriodFormState
       text: amountMinor != null ? _formatAmount(amountMinor) : '',
     );
 
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final master = widget.master;
     ref.listen<(DateTime, DateTime)>(periodBoundsProvider, (previous, next) {
       final start = next.$1;
       final end = next.$2;
@@ -99,17 +110,6 @@ class _PlannedAssignToPeriodFormState
         });
       }
     });
-  }
-
-  @override
-  void dispose() {
-    _amountController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final master = widget.master;
     final bounds = ref.watch(periodBoundsProvider);
     final periodLabel = ref.watch(periodLabelProvider);
     final nav = ref.watch(periodNavProvider);


### PR DESCRIPTION
## Summary
- move the `periodBoundsProvider` listener from `initState` to `build` so it executes in a valid Riverpod context

## Testing
- flutter analyze *(fails: `flutter` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a6d936b083268312990d7633e2f5