### PR TITLE
Remove LookupError type check

### DIFF
--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -415,6 +415,5 @@ int _clampRemainingDays(int difference, int periodDays) {
 bool _isMissingRepoMethod(Object error) {
   return error is NoSuchMethodError ||
       error is UnimplementedError ||
-      error is UnsupportedError ||
-      error is LookupError;
+      error is UnsupportedError;
 }


### PR DESCRIPTION
## Summary
- remove the LookupError check from `_isMissingRepoMethod` to fix compilation

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d435783a048326bd76ab4e772f656e