### PR TITLE
Polish home header and keypad UI

### DIFF
--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -204,6 +204,25 @@ final daysToPeriodEndProvider = Provider<int?>((ref) {
   return diff < 0 ? 0 : diff;
 });
 
+final daysFromPayoutToPeriodEndProvider = Provider<int?>((ref) {
+  final payoutAsync = ref.watch(payoutForSelectedPeriodProvider);
+  final (_, endExclusive) = ref.watch(periodBoundsProvider);
+
+  return payoutAsync.maybeWhen(
+    data: (payout) {
+      if (payout == null) {
+        return null;
+      }
+
+      final payoutDate = _normalizeDate(payout.date);
+      final endDate = _normalizeDate(endExclusive);
+      final diff = endDate.difference(payoutDate).inDays;
+      return diff < 0 ? 0 : diff;
+    },
+    orElse: () => null,
+  );
+});
+
 final dailyLimitProvider = FutureProvider<int?>((ref) async {
   ref.watch(dbTickProvider);
   final repository = ref.watch(settingsRepoProvider);

--- a/lib/ui/entry/category_screen.dart
+++ b/lib/ui/entry/category_screen.dart
@@ -10,6 +10,7 @@ import '../../state/db_refresh.dart';
 import '../categories/category_actions.dart';
 import '../categories/category_edit_form.dart';
 import '../categories/category_tree_view.dart';
+import '../widgets/category_tabs.dart';
 
 class CategoryScreen extends ConsumerWidget {
   const CategoryScreen({super.key});
@@ -111,28 +112,9 @@ class CategoryScreen extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SegmentedButton<CategoryType>(
-              segments: const [
-                ButtonSegment(
-                  value: CategoryType.income,
-                  label: Text('Доходы'),
-                  icon: Icon(Icons.trending_up),
-                ),
-                ButtonSegment(
-                  value: CategoryType.expense,
-                  label: Text('Расходы'),
-                  icon: Icon(Icons.trending_down),
-                ),
-                ButtonSegment(
-                  value: CategoryType.saving,
-                  label: Text('Сбережения'),
-                  icon: Icon(Icons.savings),
-                ),
-              ],
-              selected: {entryState.type},
-              onSelectionChanged: (value) {
-                controller.setType(value.first);
-              },
+            CategoryTabs(
+              selected: entryState.type,
+              onChanged: controller.setType,
             ),
             const SizedBox(height: 24),
             Expanded(

--- a/lib/ui/operations/operations_screen.dart
+++ b/lib/ui/operations/operations_screen.dart
@@ -43,6 +43,12 @@ class OperationsScreen extends ConsumerWidget {
     final boundsLabel =
         '${formatDayMonth(periodStart)} – ${formatDayMonth(endInclusive)}';
 
+    final mediaQuery = MediaQuery.of(context);
+    final clampedTextScale =
+        mediaQuery.textScaleFactor.clamp(0.9, 1.1).toDouble();
+    final filterTextStyle =
+        Theme.of(context).textTheme.labelLarge?.copyWith(fontSize: 14);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Операции периода'),
@@ -97,33 +103,43 @@ class OperationsScreen extends ConsumerWidget {
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: SegmentedButton<OpTypeFilter>(
-                  segments: const [
-                    ButtonSegment(
-                      value: OpTypeFilter.all,
-                      label: Text('Все'),
+                child: MediaQuery(
+                  data: mediaQuery.copyWith(textScaleFactor: clampedTextScale),
+                  child: SegmentedButton<OpTypeFilter>(
+                    segments: const [
+                      ButtonSegment(
+                        value: OpTypeFilter.all,
+                        label: _SegmentLabel('Все'),
+                      ),
+                      ButtonSegment(
+                        value: OpTypeFilter.expense,
+                        label: _SegmentLabel('Расходы'),
+                      ),
+                      ButtonSegment(
+                        value: OpTypeFilter.income,
+                        label: _SegmentLabel('Доходы'),
+                      ),
+                      ButtonSegment(
+                        value: OpTypeFilter.saving,
+                        label: _SegmentLabel('Сбережения'),
+                      ),
+                    ],
+                    selected: {filter},
+                    showSelectedIcon: false,
+                    style: ButtonStyle(
+                      visualDensity: VisualDensity.compact,
+                      padding: const MaterialStatePropertyAll(
+                        EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                      ),
+                      textStyle: MaterialStatePropertyAll(filterTextStyle),
                     ),
-                    ButtonSegment(
-                      value: OpTypeFilter.expense,
-                      label: Text('Расходы'),
-                    ),
-                    ButtonSegment(
-                      value: OpTypeFilter.income,
-                      label: Text('Доходы'),
-                    ),
-                    ButtonSegment(
-                      value: OpTypeFilter.saving,
-                      label: Text('Сбережения'),
-                    ),
-                  ],
-                  selected: {filter},
-                  showSelectedIcon: false,
-                  onSelectionChanged: (selection) {
-                    if (selection.isEmpty) {
-                      return;
-                    }
-                    ref.read(opTypeFilterProvider.notifier).state = selection.first;
-                  },
+                    onSelectionChanged: (selection) {
+                      if (selection.isEmpty) {
+                        return;
+                      }
+                      ref.read(opTypeFilterProvider.notifier).state = selection.first;
+                    },
+                  ),
                 ),
               ),
               Expanded(
@@ -164,6 +180,21 @@ class OperationsScreen extends ConsumerWidget {
           );
         },
       ),
+    );
+  }
+}
+
+class _SegmentLabel extends StatelessWidget {
+  const _SegmentLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.center,
+      child: Text(text, maxLines: 1),
     );
   }
 }

--- a/lib/ui/settings/categories_manage_screen.dart
+++ b/lib/ui/settings/categories_manage_screen.dart
@@ -7,6 +7,7 @@ import '../../state/db_refresh.dart';
 import '../categories/category_actions.dart';
 import '../categories/category_edit_form.dart';
 import '../categories/category_tree_view.dart';
+import '../widgets/category_tabs.dart';
 
 class CategoriesManageScreen extends ConsumerStatefulWidget {
   const CategoriesManageScreen({super.key});
@@ -93,27 +94,10 @@ class _CategoriesManageScreenState
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SegmentedButton<CategoryType>(
-              segments: const [
-                ButtonSegment(
-                  value: CategoryType.income,
-                  label: Text('Доходы'),
-                  icon: Icon(Icons.trending_up),
-                ),
-                ButtonSegment(
-                  value: CategoryType.expense,
-                  label: Text('Расходы'),
-                  icon: Icon(Icons.trending_down),
-                ),
-                ButtonSegment(
-                  value: CategoryType.saving,
-                  label: Text('Сбережения'),
-                  icon: Icon(Icons.savings),
-                ),
-              ],
-              selected: {_selectedType},
-              onSelectionChanged: (value) {
-                setState(() => _selectedType = value.first);
+            CategoryTabs(
+              selected: _selectedType,
+              onChanged: (value) {
+                setState(() => _selectedType = value);
               },
             ),
             const SizedBox(height: 24),

--- a/lib/ui/widgets/amount_keypad.dart
+++ b/lib/ui/widgets/amount_keypad.dart
@@ -21,72 +21,72 @@ class AmountKeypad extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final buttonStyle = ElevatedButton.styleFrom(
-      minimumSize: const Size(72, 64),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      textStyle: theme.textTheme.titleLarge,
-    );
 
-    final secondaryStyle = buttonStyle.copyWith(
-      backgroundColor: MaterialStatePropertyAll(
-        theme.colorScheme.surfaceVariant,
-      ),
-      foregroundColor: MaterialStatePropertyAll(
-        theme.colorScheme.onSurfaceVariant,
-      ),
-    );
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final mediaQuery = MediaQuery.of(context);
+        final clampedTextScale =
+            mediaQuery.textScaleFactor.clamp(0.9, 1.1).toDouble();
+        final mediaQueryData = mediaQuery.copyWith(
+          textScaleFactor: clampedTextScale,
+        );
 
-    final operatorStyle = buttonStyle.copyWith(
-      backgroundColor: MaterialStatePropertyAll(
-        theme.colorScheme.secondaryContainer,
-      ),
-      foregroundColor: MaterialStatePropertyAll(
-        theme.colorScheme.onSecondaryContainer,
-      ),
-    );
+        const baseWidth = 400.0;
+        final maxWidth = constraints.maxWidth.isFinite && constraints.maxWidth > 0
+            ? constraints.maxWidth
+            : baseWidth;
+        final normalized = maxWidth / baseWidth;
+        final scale = normalized.clamp(0.88, 0.92);
 
-    final evaluateStyle = buttonStyle.copyWith(
-      backgroundColor: MaterialStatePropertyAll(theme.colorScheme.primary),
-      foregroundColor: MaterialStatePropertyAll(theme.colorScheme.onPrimary),
-    );
+        final buttonStyle = ElevatedButton.styleFrom(
+          minimumSize: const Size(64, 56),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          textStyle: theme.textTheme.titleMedium,
+        );
 
-    Widget buildButton(
-      Widget child,
-      VoidCallback onPressed, {
-      int flex = 1,
-      ButtonStyle? style,
-    }) {
-      return Expanded(
-        flex: flex,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-          child: ElevatedButton(
-            onPressed: onPressed,
-            style: style ?? buttonStyle,
-            child: child,
+        final secondaryStyle = buttonStyle.copyWith(
+          backgroundColor: MaterialStatePropertyAll(
+            theme.colorScheme.surfaceVariant,
           ),
-        ),
-      );
-    }
+          foregroundColor: MaterialStatePropertyAll(
+            theme.colorScheme.onSurfaceVariant,
+          ),
+        );
 
-    Widget buildRow(List<Widget> children) {
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Row(
-          children: [
-            ...children,
-          ],
-        ),
-      );
-    }
+        final operatorStyle = buttonStyle.copyWith(
+          backgroundColor: MaterialStatePropertyAll(
+            theme.colorScheme.secondaryContainer,
+          ),
+          foregroundColor: MaterialStatePropertyAll(
+            theme.colorScheme.onSecondaryContainer,
+          ),
+        );
 
-    Widget buildSpacer({int flex = 1}) {
-      return Expanded(flex: flex, child: const SizedBox.shrink());
-    }
+        final evaluateStyle = buttonStyle.copyWith(
+          backgroundColor: MaterialStatePropertyAll(theme.colorScheme.primary),
+          foregroundColor: MaterialStatePropertyAll(theme.colorScheme.onPrimary),
+        );
 
-    return Column(
-      children: [
-        buildRow([
+        Widget buildButton(Widget child, VoidCallback onPressed,
+            {ButtonStyle? style}) {
+          return Padding(
+            padding: const EdgeInsets.all(4),
+            child: SizedBox.expand(
+              child: ElevatedButton(
+                onPressed: onPressed,
+                style: style ?? buttonStyle,
+                child: child,
+              ),
+            ),
+          );
+        }
+
+        Widget buildSpacer() {
+          return const SizedBox.shrink();
+        }
+
+        final children = <Widget>[
           buildButton(
             const Text('AC'),
             onAllClear,
@@ -107,8 +107,6 @@ class AmountKeypad extends StatelessWidget {
             () => onOperatorPressed('*'),
             style: operatorStyle,
           ),
-        ]),
-        buildRow([
           buildButton(const Text('7'), () => onDigitPressed('7')),
           buildButton(const Text('8'), () => onDigitPressed('8')),
           buildButton(const Text('9'), () => onDigitPressed('9')),
@@ -117,8 +115,6 @@ class AmountKeypad extends StatelessWidget {
             () => onOperatorPressed('-'),
             style: operatorStyle,
           ),
-        ]),
-        buildRow([
           buildButton(const Text('4'), () => onDigitPressed('4')),
           buildButton(const Text('5'), () => onDigitPressed('5')),
           buildButton(const Text('6'), () => onDigitPressed('6')),
@@ -127,8 +123,6 @@ class AmountKeypad extends StatelessWidget {
             () => onOperatorPressed('+'),
             style: operatorStyle,
           ),
-        ]),
-        buildRow([
           buildButton(const Text('1'), () => onDigitPressed('1')),
           buildButton(const Text('2'), () => onDigitPressed('2')),
           buildButton(const Text('3'), () => onDigitPressed('3')),
@@ -137,17 +131,35 @@ class AmountKeypad extends StatelessWidget {
             onEvaluate,
             style: evaluateStyle,
           ),
-        ]),
-        buildRow([
-          buildButton(
-            const Text('0'),
-            () => onDigitPressed('0'),
-            flex: 2,
-          ),
+          buildButton(const Text('0'), () => onDigitPressed('0')),
           buildButton(const Text('.'), onDecimal),
           buildSpacer(),
-        ]),
-      ],
+          buildSpacer(),
+        ];
+
+        final grid = MediaQuery(
+          data: mediaQueryData,
+          child: GridView.count(
+            crossAxisCount: 4,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisSpacing: 8,
+            mainAxisSpacing: 8,
+            childAspectRatio: 1.15,
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            children: children,
+          ),
+        );
+
+        return Align(
+          alignment: Alignment.topCenter,
+          child: Transform.scale(
+            scale: scale,
+            alignment: Alignment.topCenter,
+            child: grid,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/widgets/category_tabs.dart
+++ b/lib/ui/widgets/category_tabs.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/category.dart';
+
+class CategoryTabs extends StatelessWidget {
+  const CategoryTabs({
+    super.key,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final CategoryType selected;
+  final ValueChanged<CategoryType> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
+    final clampedScale = mediaQuery.textScaleFactor.clamp(0.9, 1.1).toDouble();
+    final textStyle =
+        theme.textTheme.labelLarge?.copyWith(fontSize: 14, fontWeight: FontWeight.w600);
+
+    Widget buildLabel(String text) {
+      return FittedBox(
+        fit: BoxFit.scaleDown,
+        alignment: Alignment.center,
+        child: Text(text, maxLines: 1),
+      );
+    }
+
+    return MediaQuery(
+      data: mediaQuery.copyWith(textScaleFactor: clampedScale),
+      child: SegmentedButton<CategoryType>(
+        segments: [
+          ButtonSegment(
+            value: CategoryType.income,
+            label: buildLabel('Доходы'),
+            icon: const Icon(Icons.trending_up),
+          ),
+          ButtonSegment(
+            value: CategoryType.expense,
+            label: buildLabel('Расходы'),
+            icon: const Icon(Icons.trending_down),
+          ),
+          ButtonSegment(
+            value: CategoryType.saving,
+            label: buildLabel('Сбережения'),
+            icon: const Icon(Icons.savings),
+          ),
+        ],
+        selected: {selected},
+        onSelectionChanged: (value) {
+          if (value.isEmpty) {
+            return;
+          }
+          onChanged(value.first);
+        },
+        style: ButtonStyle(
+          visualDensity: VisualDensity.compact,
+          padding: const MaterialStatePropertyAll(
+            EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          ),
+          textStyle: MaterialStatePropertyAll(textStyle),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/period_selector.dart
+++ b/lib/ui/widgets/period_selector.dart
@@ -40,9 +40,37 @@ class PeriodSelector extends ConsumerWidget {
                 borderRadius: BorderRadius.circular(999),
                 color: Theme.of(context).colorScheme.surfaceVariant,
               ),
-              child: Text(
-                displayLabel,
-                style: Theme.of(context).textTheme.labelLarge,
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 180),
+                switchInCurve: Curves.easeOut,
+                switchOutCurve: Curves.easeIn,
+                layoutBuilder: (currentChild, previousChildren) {
+                  return Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      ...previousChildren,
+                      if (currentChild != null) currentChild,
+                    ],
+                  );
+                },
+                transitionBuilder: (child, animation) {
+                  final slideAnimation = Tween<Offset>(
+                    begin: const Offset(0.12, 0),
+                    end: Offset.zero,
+                  ).animate(animation);
+                  return FadeTransition(
+                    opacity: animation,
+                    child: SlideTransition(
+                      position: slideAnimation,
+                      child: child,
+                    ),
+                  );
+                },
+                child: Text(
+                  displayLabel,
+                  key: ValueKey(displayLabel),
+                  style: Theme.of(context).textTheme.labelLarge,
+                ),
               ),
             ),
           ),

--- a/lib/utils/formatting.dart
+++ b/lib/utils/formatting.dart
@@ -6,12 +6,19 @@ final NumberFormat currencyFormat = NumberFormat.currency(
   decimalDigits: 2,
 );
 
+final NumberFormat currencyIntegerFormat = NumberFormat.decimalPattern('ru');
+
 String formatCurrency(double value) {
   return currencyFormat.format(value);
 }
 
 String formatCurrencyMinor(int value) {
   return formatCurrency(value / 100);
+}
+
+String formatCurrencyMinorToRubles(int value) {
+  final rubles = value ~/ 100;
+  return '${currencyIntegerFormat.format(rubles)}\u00A0₽';
 }
 
 String formatCurrencyMinorNullable(int? value, {String placeholder = '—'}) {


### PR DESCRIPTION
## Summary
- add a payout-based days-left provider and animate the home period header/badge updates
- render remaining budget amounts without kopecks using Russian separators
- scale the amount keypad with a compact grid layout and clamp button text scale
- introduce reusable responsive category tabs and tighten operations filter chips

## Testing
- `flutter test` *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f111ea708326b71fe6c1007fd131