### PR TITLE
Improve planned UX and aggregate saving pairs

### DIFF
--- a/lib/data/repositories/planned_master_repository.dart
+++ b/lib/data/repositories/planned_master_repository.dart
@@ -105,7 +105,7 @@ abstract class PlannedMasterRepository {
     String? note,
   });
 
-  Future<void> update(
+  Future<bool> update(
     int id, {
     String? type,
     String? title,
@@ -190,7 +190,7 @@ class SqlitePlannedMasterRepository implements PlannedMasterRepository {
   }
 
   @override
-  Future<void> update(
+  Future<bool> update(
     int id, {
     String? type,
     String? title,
@@ -219,16 +219,14 @@ class SqlitePlannedMasterRepository implements PlannedMasterRepository {
     if (archived != null) {
       values['archived'] = archived ? 1 : 0;
     }
-    if (values.isEmpty) {
-      return;
-    }
     values['updated_at'] = DateTime.now().toUtc().toIso8601String();
-    await db.update(
+    final rowsUpdated = await db.update(
       'planned_master',
       values,
       where: 'id = ?',
       whereArgs: [id],
     );
+    return rowsUpdated > 0;
   }
 
   String _normalizeType(String type) {

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -167,3 +167,9 @@ final necessityMapProvider =
     for (final label in labels) label.id: label,
   };
 });
+
+final savingPairEnabledProvider = FutureProvider<bool>((ref) async {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(settingsRepoProvider);
+  return repository.getSavingPairEnabled();
+});

--- a/lib/state/operations_filters.dart
+++ b/lib/state/operations_filters.dart
@@ -11,11 +11,13 @@ final opTypeFilterProvider = StateProvider<OpTypeFilter>((_) => OpTypeFilter.all
 
 typedef PeriodBounds = ({DateTime start, DateTime endExclusive});
 
-final periodOperationsProvider = FutureProvider.family<List<TransactionRecord>, PeriodBounds>(
+final periodOperationsProvider =
+    FutureProvider.family<List<TransactionListItem>, PeriodBounds>(
   (ref, bounds) async {
     ref.watch(dbTickProvider);
     final repository = ref.watch(transactionsRepoProvider);
     final filter = ref.watch(opTypeFilterProvider);
+    final savingPairEnabled = await ref.watch(savingPairEnabledProvider.future);
 
     TransactionType? type;
     switch (filter) {
@@ -38,11 +40,12 @@ final periodOperationsProvider = FutureProvider.family<List<TransactionRecord>, 
       endInclusive = bounds.start;
     }
 
-    return repository.getByPeriod(
+    return repository.getOperationItemsByPeriod(
       bounds.start,
       endInclusive,
       type: type,
       isPlanned: false,
+      aggregateSavingPairs: savingPairEnabled,
     );
   },
 );

--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -17,6 +17,7 @@ import '../../utils/formatting.dart';
 import '../../utils/color_hex.dart';
 import '../../utils/date_format_short.dart';
 import '../widgets/add_another_snack.dart';
+import '../widgets/necessity_choice_chip.dart';
 
 class ReviewScreen extends ConsumerStatefulWidget {
   const ReviewScreen({super.key});
@@ -60,7 +61,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
     final isIncome = operationKind == OperationKind.income;
     final isExpense = operationKind == OperationKind.expense;
     final isSaving = operationKind == OperationKind.saving;
-    final isQuickAddKind = isExpense || isIncome;
+    final isQuickAddKind = isExpense || isIncome || isSaving;
     final isPlannedExpense = isExpense && (_forcePlanned || _asPlanned);
     final showPlanToggle = isExpense && !_forcePlanned;
     final showNecessitySection = isSaving || isPlannedExpense;
@@ -375,11 +376,10 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
                                       for (var i = 0;
                                           i < necessityLabels.length;
                                           i++)
-                                        ChoiceChip(
-                                          label: Text(necessityLabels[i].name),
-                                          selected:
-                                              necessityLabels[i].id ==
-                                                  selectedNecessityLabel?.id,
+                                        NecessityChoiceChip(
+                                          label: necessityLabels[i],
+                                          selected: necessityLabels[i].id ==
+                                              selectedNecessityLabel?.id,
                                           onSelected: (_) => controller
                                               .setNecessity(
                                             id: necessityLabels[i].id,

--- a/lib/ui/planned/planned_add_form.dart
+++ b/lib/ui/planned/planned_add_form.dart
@@ -7,6 +7,7 @@ import '../../data/repositories/necessity_repository.dart';
 import '../../state/app_providers.dart';
 import '../../state/db_refresh.dart';
 import '../../state/planned_providers.dart';
+import '../widgets/necessity_choice_chip.dart';
 
 CategoryType _categoryTypeFor(PlannedType type) {
   switch (type) {
@@ -298,8 +299,8 @@ class _PlannedAddFormState extends ConsumerState<_PlannedAddForm> {
                       runSpacing: 8,
                       children: [
                         for (final label in necessityLabels)
-                          ChoiceChip(
-                            label: Text(label.name),
+                          NecessityChoiceChip(
+                            label: label,
                             selected: label.id == selectedNecessityId,
                             onSelected: (_) {
                               setState(() {

--- a/lib/ui/planned/planned_library_screen.dart
+++ b/lib/ui/planned/planned_library_screen.dart
@@ -185,11 +185,13 @@ class _PlannedLibraryScreenState
       return;
     }
     final repo = ref.read(plannedMasterRepoProvider);
-    await repo.update(id, archived: !master.archived);
+    final updated = await repo.update(id, archived: !master.archived);
     if (!mounted) {
       return;
     }
-    bumpDbTick(ref);
+    if (updated) {
+      bumpDbTick(ref);
+    }
   }
 
   Future<void> _deleteMaster(BuildContext context, PlannedMaster master) async {

--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -223,6 +223,7 @@ class _PlannedMasterEditFormState
     setState(() => _isSaving = true);
     try {
       final initial = widget.initial;
+      var changed = false;
       if (initial == null) {
         await repo.create(
           type: _type,
@@ -231,10 +232,11 @@ class _PlannedMasterEditFormState
           categoryId: _categoryId,
           note: note,
         );
+        changed = true;
       } else {
         final id = initial.id;
         if (id != null) {
-          await repo.update(
+          changed = await repo.update(
             id,
             type: _type,
             title: title,
@@ -247,7 +249,9 @@ class _PlannedMasterEditFormState
       if (!mounted) {
         return;
       }
-      bumpDbTick(ref);
+      if (changed) {
+        bumpDbTick(ref);
+      }
       Navigator.of(context).pop();
     } finally {
       if (mounted) {

--- a/lib/ui/widgets/necessity_choice_chip.dart
+++ b/lib/ui/widgets/necessity_choice_chip.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../../data/repositories/necessity_repository.dart'
+    as necessity_repo;
+import '../../utils/color_hex.dart';
+
+class NecessityChoiceChip extends StatelessWidget {
+  const NecessityChoiceChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final necessity_repo.NecessityLabel label;
+  final bool selected;
+  final ValueChanged<bool> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = hexToColor(label.color);
+    final selectedColor = color ?? theme.colorScheme.secondaryContainer;
+    final backgroundColor =
+        color != null ? color.withOpacity(0.16) : theme.colorScheme.surfaceVariant;
+    final borderColor = (color ?? theme.colorScheme.outline).withOpacity(0.6);
+    final onSelectedColor =
+        ThemeData.estimateBrightnessForColor(selectedColor) == Brightness.dark
+            ? Colors.white
+            : Colors.black;
+
+    return ChoiceChip(
+      label: Text(
+        label.name,
+        style: TextStyle(
+          color: selected ? onSelectedColor : theme.colorScheme.onSurface,
+        ),
+      ),
+      selected: selected,
+      selectedColor: selectedColor,
+      backgroundColor: backgroundColor,
+      checkmarkColor: onSelectedColor,
+      side: BorderSide(color: borderColor),
+      onSelected: onSelected,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the assign-to-period sheet to scroll safely and pin the actions bar
- show all planned instances with dimmed excluded entries and colourised necessity chips
- aggregate saving pairs in the operations flow and refresh master updates immediately

## Testing
- flutter test *(fails: flutter CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f78e9e60832692ccd7887d24d8c1