### PR TITLE
Add bulk category move and improve UX details

### DIFF
--- a/lib/data/repositories/categories_repository.dart
+++ b/lib/data/repositories/categories_repository.dart
@@ -16,6 +16,8 @@ abstract class CategoriesRepository {
 
   Future<void> delete(int id);
 
+  Future<void> bulkMove(List<int> ids, int? parentId);
+
   Future<List<Category>> groupsByType(CategoryType type);
 
   Future<List<Category>> childrenOf(int groupId);
@@ -47,6 +49,21 @@ class SqliteCategoriesRepository implements CategoriesRepository {
       {'parent_id': null},
       where: 'parent_id = ?',
       whereArgs: [id],
+    );
+  }
+
+  @override
+  Future<void> bulkMove(List<int> ids, int? parentId) async {
+    if (ids.isEmpty) {
+      return;
+    }
+    final db = await _db;
+    final placeholders = List.filled(ids.length, '?').join(',');
+    await db.update(
+      'categories',
+      {'parent_id': parentId},
+      where: 'id IN ($placeholders)',
+      whereArgs: ids,
     );
   }
 

--- a/lib/ui/categories/category_tree_view.dart
+++ b/lib/ui/categories/category_tree_view.dart
@@ -15,6 +15,9 @@ class CategoryTreeView extends StatelessWidget {
     this.onCategoryLongPress,
     this.onGroupTap,
     this.onGroupLongPress,
+    this.selectionMode = false,
+    this.selectedCategoryIds = const <int>{},
+    this.onCategorySelectionToggle,
   });
 
   final List<Category> groups;
@@ -24,6 +27,9 @@ class CategoryTreeView extends StatelessWidget {
   final CategoryCallback? onCategoryLongPress;
   final CategoryCallback? onGroupTap;
   final CategoryCallback? onGroupLongPress;
+  final bool selectionMode;
+  final Set<int> selectedCategoryIds;
+  final CategoryCallback? onCategorySelectionToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +56,9 @@ class CategoryTreeView extends StatelessWidget {
         onCategoryLongPress: onCategoryLongPress,
         onGroupTap: onGroupTap != null ? () => onGroupTap!(group) : null,
         onGroupLongPress: onGroupLongPress,
+        selectionMode: selectionMode,
+        selectedCategoryIds: selectedCategoryIds,
+        onCategorySelectionToggle: onCategorySelectionToggle,
       ));
       items.add(const SizedBox(height: 12));
     }
@@ -70,8 +79,12 @@ class CategoryTreeView extends StatelessWidget {
       for (final category in ungrouped) {
         items.add(_CategoryCard(
           category: category,
-          onTap: onCategoryTap,
-          onLongPress: onCategoryLongPress,
+          onTap: selectionMode ? null : onCategoryTap,
+          onLongPress: selectionMode ? null : onCategoryLongPress,
+          selectionMode: selectionMode,
+          selected: category.id != null &&
+              selectedCategoryIds.contains(category.id),
+          onSelectionToggle: onCategorySelectionToggle,
         ));
         items.add(const SizedBox(height: 12));
       }
@@ -96,6 +109,9 @@ class _GroupCard extends StatefulWidget {
     this.onCategoryLongPress,
     this.onGroupTap,
     this.onGroupLongPress,
+    this.selectionMode = false,
+    this.selectedCategoryIds = const <int>{},
+    this.onCategorySelectionToggle,
   });
 
   final Category group;
@@ -104,6 +120,9 @@ class _GroupCard extends StatefulWidget {
   final CategoryCallback? onCategoryLongPress;
   final VoidCallback? onGroupTap;
   final CategoryCallback? onGroupLongPress;
+  final bool selectionMode;
+  final Set<int> selectedCategoryIds;
+  final CategoryCallback? onCategorySelectionToggle;
 
   @override
   State<_GroupCard> createState() => _GroupCardState();
@@ -135,10 +154,12 @@ class _GroupCardState extends State<_GroupCard> {
               child: Icon(Icons.folder, color: color),
             ),
             title: Text(widget.group.name),
-            onTap: widget.onGroupTap ?? (hasChildren ? _toggleExpansion : null),
-            onLongPress: widget.onGroupLongPress != null
-                ? () => widget.onGroupLongPress!(widget.group)
-                : null,
+            onTap: widget.selectionMode
+                ? (hasChildren ? _toggleExpansion : null)
+                : widget.onGroupTap ?? (hasChildren ? _toggleExpansion : null),
+            onLongPress: widget.selectionMode || widget.onGroupLongPress == null
+                ? null
+                : () => widget.onGroupLongPress!(widget.group),
             trailing: hasChildren
                 ? IconButton(
                     icon: Icon(
@@ -152,9 +173,14 @@ class _GroupCardState extends State<_GroupCard> {
             ...widget.children.map(
               (category) => _CategoryTile(
                 category: category,
-                onTap: widget.onCategoryTap,
-                onLongPress: widget.onCategoryLongPress,
+                onTap: widget.selectionMode ? null : widget.onCategoryTap,
+                onLongPress:
+                    widget.selectionMode ? null : widget.onCategoryLongPress,
                 contentPadding: const EdgeInsets.fromLTRB(24, 0, 16, 0),
+                selectionMode: widget.selectionMode,
+                selected: category.id != null &&
+                    widget.selectedCategoryIds.contains(category.id),
+                onSelectionToggle: widget.onCategorySelectionToggle,
               ),
             ),
         ],
@@ -169,22 +195,44 @@ class _CategoryTile extends StatelessWidget {
     this.onTap,
     this.onLongPress,
     this.contentPadding,
+    this.selectionMode = false,
+    this.selected = false,
+    this.onSelectionToggle,
   });
 
   final Category category;
   final CategoryCallback? onTap;
   final CategoryCallback? onLongPress;
   final EdgeInsetsGeometry? contentPadding;
+  final bool selectionMode;
+  final bool selected;
+  final CategoryCallback? onSelectionToggle;
 
   @override
   Widget build(BuildContext context) {
     final color = category.type.color;
+    final avatar = CircleAvatar(
+      backgroundColor: color.withOpacity(0.15),
+      child: Icon(Icons.label, color: color),
+    );
+    if (selectionMode) {
+      final hasId = category.id != null;
+      return CheckboxListTile(
+        value: hasId && selected,
+        onChanged: hasId
+            ? (_) => onSelectionToggle?.call(category)
+            : null,
+        title: Text(category.name),
+        secondary: avatar,
+        contentPadding:
+            contentPadding ?? const EdgeInsets.symmetric(horizontal: 16),
+        controlAffinity: ListTileControlAffinity.leading,
+        selected: selected,
+      );
+    }
     return ListTile(
       contentPadding: contentPadding,
-      leading: CircleAvatar(
-        backgroundColor: color.withOpacity(0.15),
-        child: Icon(Icons.label, color: color),
-      ),
+      leading: avatar,
       title: Text(category.name),
       onTap: onTap != null ? () => onTap!(category) : null,
       onLongPress: onLongPress != null ? () => onLongPress!(category) : null,
@@ -197,11 +245,17 @@ class _CategoryCard extends StatelessWidget {
     required this.category,
     this.onTap,
     this.onLongPress,
+    this.selectionMode = false,
+    this.selected = false,
+    this.onSelectionToggle,
   });
 
   final Category category;
   final CategoryCallback? onTap;
   final CategoryCallback? onLongPress;
+  final bool selectionMode;
+  final bool selected;
+  final CategoryCallback? onSelectionToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -210,6 +264,9 @@ class _CategoryCard extends StatelessWidget {
         category: category,
         onTap: onTap,
         onLongPress: onLongPress,
+        selectionMode: selectionMode,
+        selected: selected,
+        onSelectionToggle: onSelectionToggle,
       ),
     );
   }

--- a/lib/ui/settings/necessity_settings_screen.dart
+++ b/lib/ui/settings/necessity_settings_screen.dart
@@ -201,6 +201,8 @@ class NecessitySettingsScreen extends ConsumerStatefulWidget {
 
 class _NecessitySettingsScreenState
     extends ConsumerState<NecessitySettingsScreen> {
+  static const double _itemHeight = 76;
+
   @override
   Widget build(BuildContext context) {
     final labelsAsync = ref.watch(necessityLabelsFutureProvider);
@@ -238,40 +240,45 @@ class _NecessitySettingsScreenState
               itemCount: labels.length,
               onReorder: _handleReorder,
               buildDefaultDragHandles: false,
+              proxyDecorator: (child, index, animation) => child,
               itemBuilder: (context, index) {
                 final label = labels[index];
                 final hasColor = label.color?.trim().isNotEmpty == true;
                 final color = hexToColor(label.color);
-                return Card(
+                return SizedBox(
                   key: ValueKey(label.id),
-                  child: ListTile(
-                    leading: CircleAvatar(
-                      backgroundColor: color ??
-                          Theme.of(context).colorScheme.surfaceVariant,
-                      child: hasColor
-                          ? null
-                          : const Icon(Icons.block, size: 16),
-                    ),
-                    title: Text(label.name),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        ReorderableDragStartListener(
-                          index: index,
-                          child: const Icon(Icons.drag_handle),
-                        ),
-                        IconButton(
-                          tooltip: 'Переименовать',
-                          onPressed: () =>
-                              showNecessityEditSheet(context, initial: label),
-                          icon: const Icon(Icons.edit),
-                        ),
-                        IconButton(
-                          tooltip: 'Скрыть',
-                          onPressed: () => _archiveLabel(label),
-                          icon: const Icon(Icons.archive),
-                        ),
-                      ],
+                  height: _itemHeight,
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    child: ListTile(
+                      leading: CircleAvatar(
+                        backgroundColor: color ??
+                            Theme.of(context).colorScheme.surfaceVariant,
+                        child: hasColor
+                            ? null
+                            : const Icon(Icons.block, size: 16),
+                      ),
+                      title: Text(label.name),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ReorderableDragStartListener(
+                            index: index,
+                            child: const Icon(Icons.drag_handle),
+                          ),
+                          IconButton(
+                            tooltip: 'Переименовать',
+                            onPressed: () =>
+                                showNecessityEditSheet(context, initial: label),
+                            icon: const Icon(Icons.edit),
+                          ),
+                          IconButton(
+                            tooltip: 'Скрыть',
+                            onPressed: () => _archiveLabel(label),
+                            icon: const Icon(Icons.archive),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 );

--- a/lib/ui/settings/reasons_settings_screen.dart
+++ b/lib/ui/settings/reasons_settings_screen.dart
@@ -200,6 +200,8 @@ class ReasonsSettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _ReasonsSettingsScreenState extends ConsumerState<ReasonsSettingsScreen> {
+  static const double _itemHeight = 76;
+
   @override
   Widget build(BuildContext context) {
     final labelsAsync = ref.watch(reasonLabelsProvider);
@@ -241,38 +243,43 @@ class _ReasonsSettingsScreenState extends ConsumerState<ReasonsSettingsScreen> {
               itemCount: labels.length,
               onReorder: _handleReorder,
               buildDefaultDragHandles: false,
+              proxyDecorator: (child, index, animation) => child,
               itemBuilder: (context, index) {
                 final label = labels[index];
                 final hasColor = label.color?.trim().isNotEmpty == true;
                 final color = hexToColor(label.color);
-                return Card(
+                return SizedBox(
                   key: ValueKey(label.id),
-                  child: ListTile(
-                    leading: CircleAvatar(
-                      backgroundColor:
-                          color ?? Theme.of(context).colorScheme.surfaceVariant,
-                      child: hasColor ? null : const Icon(Icons.block, size: 16),
-                    ),
-                    title: Text(label.name),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        ReorderableDragStartListener(
-                          index: index,
-                          child: const Icon(Icons.drag_handle),
-                        ),
-                        IconButton(
-                          tooltip: 'Переименовать',
-                          onPressed: () =>
-                              showReasonEditSheet(context, initial: label),
-                          icon: const Icon(Icons.edit),
-                        ),
-                        IconButton(
-                          tooltip: 'Скрыть',
-                          onPressed: () => _archiveLabel(label),
-                          icon: const Icon(Icons.archive),
-                        ),
-                      ],
+                  height: _itemHeight,
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    child: ListTile(
+                      leading: CircleAvatar(
+                        backgroundColor:
+                            color ?? Theme.of(context).colorScheme.surfaceVariant,
+                        child: hasColor ? null : const Icon(Icons.block, size: 16),
+                      ),
+                      title: Text(label.name),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ReorderableDragStartListener(
+                            index: index,
+                            child: const Icon(Icons.drag_handle),
+                          ),
+                          IconButton(
+                            tooltip: 'Переименовать',
+                            onPressed: () =>
+                                showReasonEditSheet(context, initial: label),
+                            icon: const Icon(Icons.edit),
+                          ),
+                          IconButton(
+                            tooltip: 'Скрыть',
+                            onPressed: () => _archiveLabel(label),
+                            icon: const Icon(Icons.archive),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 );

--- a/lib/ui/widgets/add_another_snack.dart
+++ b/lib/ui/widgets/add_another_snack.dart
@@ -51,6 +51,7 @@ class _AddAnotherContentState extends State<_AddAnotherContent>
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final indicatorColor = colorScheme.onSurface.withOpacity(0.65);
     return InkWell(
       onTap: () {
         ScaffoldMessenger.maybeOf(context)?.hideCurrentSnackBar();
@@ -73,6 +74,8 @@ class _AddAnotherContentState extends State<_AddAnotherContent>
                     CircularProgressIndicator(
                       value: 1 - _c.value,
                       strokeWidth: 3,
+                      valueColor: AlwaysStoppedAnimation(indicatorColor),
+                      backgroundColor: colorScheme.onSurface.withOpacity(0.15),
                     ),
                     Text(
                       '$left',


### PR DESCRIPTION
## Summary
- adjust the snackbar countdown indicator to use themed progress colors in dark mode
- rework the reorderable lists for necessity and reason settings to keep items steady while dragging
- add multi-select mode and bulk move flow for categories, including repository support and checkbox UI

## Testing
- not run (flutter tool not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5191d408c8326967889d32d1d8813