### PR TITLE
Implement payout clamp logic and period navigation updates

### DIFF
--- a/lib/ui/payouts/payout_edit_sheet.dart
+++ b/lib/ui/payouts/payout_edit_sheet.dart
@@ -341,25 +341,18 @@ class _PayoutEditSheetState extends ConsumerState<_PayoutEditSheet> {
     try {
       final payoutsRepo = ref.read(payoutsRepoProvider);
       final normalizedDate = DateTime(_date.year, _date.month, _date.day);
-      final dateToSave = _clampToPeriod(normalizedDate);
       final initial = widget.initial;
       final type = _resolveType();
-      if (initial?.id != null) {
-        await payoutsRepo.update(
-          id: initial!.id!,
-          type: type,
-          date: dateToSave,
-          amountMinor: amountMinor,
-          accountId: accountId,
-        );
-      } else {
-        await payoutsRepo.add(
-          type,
-          dateToSave,
-          amountMinor,
-          accountId: accountId,
-        );
-      }
+      final selected = ref.read(selectedPeriodRefProvider);
+      final result = await payoutsRepo.upsertWithClampToSelectedPeriod(
+        existing: initial,
+        selectedPeriod: selected,
+        pickedDate: normalizedDate,
+        type: type,
+        amountMinor: amountMinor,
+        accountId: accountId,
+      );
+      ref.read(selectedPeriodRefProvider.notifier).state = result.period;
       bumpDbTick(ref);
       if (!mounted) {
         return;

--- a/lib/ui/widgets/period_selector.dart
+++ b/lib/ui/widgets/period_selector.dart
@@ -76,6 +76,14 @@ class PeriodSelector extends ConsumerWidget {
           ),
         ),
         IconButton(
+          icon: const Icon(Icons.my_location),
+          onPressed: nav.goToToday,
+          tooltip: 'Вернуться к текущему периоду',
+          padding: iconPadding,
+          constraints: iconConstraints,
+          visualDensity: iconDensity,
+        ),
+        IconButton(
           icon: const Icon(Icons.chevron_right),
           onPressed: nav.next,
           tooltip: 'Следующий период',

--- a/lib/utils/period_utils.dart
+++ b/lib/utils/period_utils.dart
@@ -1,0 +1,142 @@
+import 'dart:math' as math;
+
+enum HalfPeriod { first, second }
+
+class PeriodRef {
+  final int year;
+  final int month;
+  final HalfPeriod half;
+
+  const PeriodRef({required this.year, required this.month, required this.half});
+
+  PeriodRef copyWith({int? year, int? month, HalfPeriod? half}) {
+    return PeriodRef(
+      year: year ?? this.year,
+      month: month ?? this.month,
+      half: half ?? this.half,
+    );
+  }
+
+  PeriodRef prevHalf() {
+    if (half == HalfPeriod.second) {
+      return copyWith(half: HalfPeriod.first);
+    }
+    final previousMonth = DateTime(year, month - 1, 1);
+    return PeriodRef(
+      year: previousMonth.year,
+      month: previousMonth.month,
+      half: HalfPeriod.second,
+    );
+  }
+
+  PeriodRef nextHalf() {
+    if (half == HalfPeriod.first) {
+      return copyWith(half: HalfPeriod.second);
+    }
+    final nextMonth = DateTime(year, month + 1, 1);
+    return PeriodRef(
+      year: nextMonth.year,
+      month: nextMonth.month,
+      half: HalfPeriod.first,
+    );
+  }
+}
+
+DateTime normalizeDate(DateTime date) {
+  return DateTime(date.year, date.month, date.day);
+}
+
+({DateTime start, DateTime endExclusive}) periodBoundsFor(
+  PeriodRef period,
+  int anchor1,
+  int anchor2,
+) {
+  final ascending = anchor1 <= anchor2;
+  final start = _anchorDate(
+    period.year,
+    period.month,
+    period.half == HalfPeriod.first ? anchor1 : anchor2,
+  );
+
+  DateTime endExclusive;
+  if (period.half == HalfPeriod.first) {
+    endExclusive = ascending
+        ? _anchorDate(period.year, period.month, anchor2)
+        : _anchorDate(period.year, period.month + 1, anchor2);
+  } else {
+    endExclusive = ascending
+        ? _anchorDate(period.year, period.month + 1, anchor1)
+        : _anchorDate(period.year, period.month, anchor1);
+  }
+
+  if (!endExclusive.isAfter(start)) {
+    endExclusive = start.add(const Duration(days: 1));
+  }
+
+  return (start: start, endExclusive: endExclusive);
+}
+
+PeriodRef periodRefForDate(DateTime date, int anchor1, int anchor2) {
+  final normalized = normalizeDate(date);
+  final ascending = anchor1 <= anchor2;
+  if (!ascending) {
+    // Нормализуем порядок якорей и пересчитываем.
+    return periodRefForDate(normalized, anchor2, anchor1);
+  }
+
+  final firstStart = _anchorDate(normalized.year, normalized.month, anchor1);
+  final secondStart = _anchorDate(normalized.year, normalized.month, anchor2);
+  final secondEndExclusive = _anchorDate(normalized.year, normalized.month + 1, anchor1);
+
+  if (normalized.isBefore(firstStart)) {
+    final previousMonth = DateTime(normalized.year, normalized.month - 1, 1);
+    return PeriodRef(year: previousMonth.year, month: previousMonth.month, half: HalfPeriod.second);
+  }
+
+  if (normalized.isBefore(secondStart)) {
+    return PeriodRef(year: normalized.year, month: normalized.month, half: HalfPeriod.first);
+  }
+
+  if (normalized.isBefore(secondEndExclusive)) {
+    return PeriodRef(year: normalized.year, month: normalized.month, half: HalfPeriod.second);
+  }
+
+  final nextMonth = DateTime(normalized.year, normalized.month + 1, 1);
+  return PeriodRef(year: nextMonth.year, month: nextMonth.month, half: HalfPeriod.first);
+}
+
+DateTime nextAnchorDate(DateTime from, int anchor1, int anchor2) {
+  final normalized = normalizeDate(from);
+  final smaller = math.min(anchor1, anchor2);
+  final larger = math.max(anchor1, anchor2);
+
+  if (normalized.day < larger) {
+    return _anchorDate(normalized.year, normalized.month, larger);
+  }
+
+  final nextMonth = DateTime(normalized.year, normalized.month + 1, 1);
+  return _anchorDate(nextMonth.year, nextMonth.month, smaller);
+}
+
+DateTime previousAnchorDate(DateTime from, int anchor1, int anchor2) {
+  final normalized = normalizeDate(from);
+  final smaller = math.min(anchor1, anchor2);
+  final larger = math.max(anchor1, anchor2);
+
+  if (normalized.day <= smaller) {
+    final previousMonth = DateTime(normalized.year, normalized.month - 1, 1);
+    return _anchorDate(previousMonth.year, previousMonth.month, larger);
+  }
+
+  if (normalized.day <= larger) {
+    return _anchorDate(normalized.year, normalized.month, smaller);
+  }
+
+  return _anchorDate(normalized.year, normalized.month, larger);
+}
+
+DateTime _anchorDate(int year, int month, int day) {
+  final lastDay = DateTime(year, month + 1, 0).day;
+  final safeDay = day.clamp(1, lastDay);
+  return DateTime(year, month, safeDay);
+}


### PR DESCRIPTION
## Summary
- add shared period utilities with half-period navigation helpers
- clamp payout dates around the selected half-period, ensuring linked income transactions stay in sync
- update providers and UI to reflect true payout periods, including a "return to current period" control

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d52eb995008326a26c6d85490006fb