### PR TITLE
feat: enhance entry review with account selection and amount editing

### DIFF
--- a/lib/data/mock/mock_repositories.dart
+++ b/lib/data/mock/mock_repositories.dart
@@ -80,6 +80,8 @@ class AccountsRepository {
   ];
 
   List<Account> getAccounts() => List.unmodifiable(_accounts);
+
+  List<Account> listActive() => List.unmodifiable(_accounts);
 }
 
 class CategoriesRepository extends ChangeNotifier {

--- a/lib/data/repositories/accounts_repository.dart
+++ b/lib/data/repositories/accounts_repository.dart
@@ -8,6 +8,8 @@ abstract class AccountsRepository {
 
   Future<Account?> getById(int id);
 
+  Future<List<Account>> listActive();
+
   Future<int> create(Account account);
 
   Future<void> update(Account account);
@@ -46,6 +48,17 @@ class SqliteAccountsRepository implements AccountsRepository {
   Future<List<Account>> getAll() async {
     final db = await _db;
     final rows = await db.query('accounts', orderBy: 'name');
+    return rows.map(Account.fromMap).toList();
+  }
+
+  @override
+  Future<List<Account>> listActive() async {
+    final db = await _db;
+    final rows = await db.query(
+      'accounts',
+      where: 'is_archived = 0',
+      orderBy: 'name',
+    );
     return rows.map(Account.fromMap).toList();
   }
 

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -37,6 +37,13 @@ final accountsDbProvider =
   return repository.getAll();
 });
 
+final activeAccountsProvider =
+    FutureProvider<List<account_models.Account>>((ref) {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(accountsRepoProvider);
+  return repository.listActive();
+});
+
 final categoriesRepositoryProvider =
     Provider<categories_repo.CategoriesRepository>((ref) {
   final database = ref.watch(appDatabaseProvider);

--- a/lib/state/entry_flow_providers.dart
+++ b/lib/state/entry_flow_providers.dart
@@ -313,6 +313,19 @@ class EntryFlowController extends StateNotifier<EntryFlowState> {
     state = state.copyWith(selectedDate: DateTime(date.year, date.month, date.day));
   }
 
+  void setAccount(int? accountId) {
+    state = state.copyWith(accountId: accountId);
+  }
+
+  void setAmountMinor(int amountMinor) {
+    final amount = amountMinor / 100;
+    state = state.copyWith(
+      expression: _formatExpressionValue(amount),
+      result: amount,
+      previewResult: amount,
+    );
+  }
+
   void setNote(String note) {
     state = state.copyWith(note: note);
   }


### PR DESCRIPTION
## Summary
- show review card dates and date picker chips with localized "EE, d MMM" formatting backed by value notifiers
- surface active account selection with required validation and sync into the entry flow
- add calculator-based amount editing for existing records and update entry controller helpers to support it

## Testing
- Not run (flutter command unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d53ae4e6ec832681f513c18fb0266f