### PR TITLE
Auto-adjust daily limit after payout updates

### DIFF
--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -191,7 +191,7 @@ class HomeScreen extends ConsumerWidget {
                   }
                   return _LimitCards(
                     leftToday: ref.watch(leftTodayMinorProvider),
-                    leftPeriod: ref.watch(leftInPeriodMinorProvider),
+                    leftPeriod: ref.watch(periodBudgetMinorProvider),
                     onEditLimit: () async {
                       final saved = await showEditDailyLimitSheet(context, ref);
                       if (!context.mounted || !saved) {

--- a/lib/ui/payouts/payout_edit_sheet.dart
+++ b/lib/ui/payouts/payout_edit_sheet.dart
@@ -352,10 +352,21 @@ class _PayoutEditSheetState extends ConsumerState<_PayoutEditSheet> {
         amountMinor: amountMinor,
         accountId: accountId,
       );
+      final limitManager = ref.read(budgetLimitManagerProvider);
+      final adjustedLimit = await limitManager.adjustDailyLimitIfNeeded(
+        payout: result.payout,
+        period: result.period,
+      );
       ref.read(selectedPeriodRefProvider.notifier).state = result.period;
       bumpDbTick(ref);
       if (!mounted) {
         return;
+      }
+      if (adjustedLimit != null) {
+        final formatted = formatCurrencyMinorToRubles(adjustedLimit);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Лимит скорректирован до $formatted')),
+        );
       }
       Navigator.of(context).pop();
     } catch (error) {


### PR DESCRIPTION
## Summary
- recalculate the period budget based on the current daily limit and remaining days, wiring it into the home screen cards
- add a budget limit manager that clamps the stored daily limit after payout changes and bumps db ticks
- show a snackbar when the daily limit is automatically corrected during payout edits

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d53ec14d588326aa12c84b1bd53cbc