### PR TITLE
Fix missing imports and date normalization

### DIFF
--- a/lib/data/repositories/payouts_repository.dart
+++ b/lib/data/repositories/payouts_repository.dart
@@ -157,8 +157,8 @@ class SqlitePayoutsRepository implements PayoutsRepository {
       'payouts',
       where: 'date >= ? AND date < ?',
       whereArgs: [
-        _formatDate(_normalizeDate(start)),
-        _formatDate(_normalizeDate(endExclusive)),
+        _formatDate(normalizeDate(start)),
+        _formatDate(normalizeDate(endExclusive)),
       ],
       orderBy: 'date DESC, id DESC',
       limit: 1,
@@ -176,8 +176,8 @@ class SqlitePayoutsRepository implements PayoutsRepository {
       'payouts',
       where: 'date >= ? AND date < ?',
       whereArgs: [
-        _formatDate(_normalizeDate(start)),
-        _formatDate(_normalizeDate(endExclusive)),
+        _formatDate(normalizeDate(start)),
+        _formatDate(normalizeDate(endExclusive)),
       ],
       orderBy: 'date DESC, id DESC',
     );

--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -554,6 +554,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
                                             ),
                                             child: const Text('Изменить сумму'),
                                           ),
+                                          ),
                                         ],
                                     ],
                                   );

--- a/lib/ui/planned/planned_assign_to_period_sheet.dart
+++ b/lib/ui/planned/planned_assign_to_period_sheet.dart
@@ -10,6 +10,7 @@ import '../../state/budget_providers.dart';
 import '../../state/db_refresh.dart';
 import '../../state/planned_master_providers.dart';
 import '../../utils/formatting.dart';
+import '../../utils/period_utils.dart';
 import '../widgets/necessity_choice_chip.dart';
 
 Future<bool?> showPlannedAssignToPeriodSheet(

--- a/lib/ui/widgets/period_selector.dart
+++ b/lib/ui/widgets/period_selector.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../state/budget_providers.dart';
+import '../../utils/period_utils.dart';
 
 class PeriodSelector extends ConsumerWidget {
   final bool dense;


### PR DESCRIPTION
## Summary
- add the period utils import to widgets that rely on `PeriodRef` and `HalfPeriod`
- normalize dates in payout range queries using the shared helper
- close the review screen amount editor button widget tree properly to fix compilation

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d54a146ec08326a3a42917799d4500