### PR TITLE
Fix APK output naming for Android build variants

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,10 +1,11 @@
+import com.android.build.api.variant.ApplicationVariant
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
-
 android {
     namespace = "com.example.finance_app"
     compileSdk = flutter.compileSdkVersion
@@ -54,10 +55,12 @@ android {
 
 androidComponents {
     onVariants(selector().all()) { variant ->
-        variant.outputs.forEach { output ->
+        if (variant is ApplicationVariant) {
             val buildType = variant.buildType
-            val verName = variant.versionName.get()
-            output.outputFileName.set("Uchet_finansov-${verName}-${buildType}.apk")
+            val verName = variant.versionName.orNull ?: ""
+            variant.outputs.forEach { output ->
+                output.outputFileName.set("Uchet_finansov-${verName}-${buildType}.apk")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- import `ApplicationVariant` and guard the output filename configuration so the script only touches application variants
- safely read the version name before setting the customized APK filename to avoid unresolved references during compilation

## Testing
- ⚠️ `./gradlew app:assembleDebug` *(fails: Gradle wrapper not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d681ab2c508326a0f44985d791c1b4