### PR TITLE
Fix APK output configuration for AGP 8

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,7 +57,7 @@ fun apkFileName(verName: String, buildType: String) =
 
 // Попытка определить версию AGP и выбрать API
 val agpVer: String = try {
-    com.android.build.gradle.internal.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
 } catch (_: Throwable) {
     "8.0.0" // пусть по умолчанию будет новая ветка
 }
@@ -70,14 +70,12 @@ if (agpVer.startsWith("8") || agpVer.startsWith("9")) {
             val vName = variant.outputs.first().versionName.orNull
                 ?: android.defaultConfig.versionName
                 ?: "0.0.0"
-            val bType = variant.buildType
+            val bType = variant.buildType ?: variant.name
 
             variant.outputs.forEach { out ->
                 // Без import: полное имя класса
-                val apkOut = out as? com.android.build.api.variant.ApkVariantOutput
-                if (apkOut != null) {
-                    apkOut.outputFileName.set(apkFileName(vName, bType))
-                }
+                val apkOut = out as? com.android.build.api.variant.ApplicationVariantOutput
+                apkOut?.outputFileName?.set(apkFileName(vName, bType))
             }
         }
     }


### PR DESCRIPTION
## Summary
- switch the AGP 8+ branch to cast outputs to ApplicationVariantOutput before renaming APKs
- guard the filename property access with null-safe calls to avoid unresolved references

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6876b569c83268644c2bb15045536