### PR TITLE
Fix AGP 8 variant output usage

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -73,11 +73,7 @@ if (agpVer.startsWith("8") || agpVer.startsWith("9")) {
             val bType = variant.buildType ?: variant.name
 
             variant.outputs.forEach { out ->
-                // Без import: полное имя класса
-                val apkOut = out as? com.android.build.api.variant.ApkVariantOutput
-                if (apkOut != null) {
-                    apkOut.outputFileName.set(apkFileName(vName, bType))
-                }
+                out.outputFileName.set(apkFileName(vName, bType))
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove the cast to the removed ApkVariantOutput type and set the file name directly on VariantOutput instances

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d68a03db408326853a15bea07fddb9