### PR TITLE
Fix nullable return type for period queries

### DIFF
--- a/lib/data/repositories/periods_repository.dart
+++ b/lib/data/repositories/periods_repository.dart
@@ -216,7 +216,7 @@ class SqlitePeriodsRepository implements PeriodsRepository {
     });
   }
 
-  Future<Map<String, Object?>>? _findPeriod(
+  Future<Map<String, Object?>?> _findPeriod(
     DatabaseExecutor executor,
     int year,
     int month,
@@ -234,7 +234,7 @@ class SqlitePeriodsRepository implements PeriodsRepository {
     return rows.first;
   }
 
-  Future<Map<String, Object?>>? _findById(DatabaseExecutor executor, int id) async {
+  Future<Map<String, Object?>?> _findById(DatabaseExecutor executor, int id) async {
     final rows = await executor.query(
       'periods',
       where: 'id = ?',


### PR DESCRIPTION
## Summary
- adjust period lookup helpers to return a nullable map while keeping async contract

## Testing
- not run (environment missing Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68d68ecd05948326b53aa8693180c7ad