### PR TITLE
Fix manual backup export and import flows

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   path: ^1.9.0
   path_provider: ^2.1.4
   file_picker: ^8.1.2
-  share_plus: ^10.1.1
 
   cupertino_icons: ^1.0.8
 


### PR DESCRIPTION
## Summary
- switch manual backup export from sharing to a save-to-device flow using the file picker
- add graceful fallbacks when the platform does not support extension filters and validate the selected file type
- remove the unused share_plus dependency

## Testing
- Not run (flutter is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6ee6b2a608326b83e77df9fd03270