### PR TITLE
Fix planned item editing dropping plan details

### DIFF
--- a/lib/ui/planned/planned_add_form.dart
+++ b/lib/ui/planned/planned_add_form.dart
@@ -419,6 +419,7 @@ class _PlannedAddFormState extends ConsumerState<_PlannedAddForm> {
       amountMinor: amountMinor,
       date: existing?.date ?? DateTime.now(),
       note: title,
+      plannedId: existing?.plannedId,
       isPlanned: true,
       includedInPeriod: existing?.includedInPeriod ?? false,
       criticality: criticality,


### PR DESCRIPTION
## Summary
- preserve the link to the original plan when updating a planned transaction so edits to its name and amount persist

## Testing
- not run (Flutter SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d6f519cab08326ab210a132c3a3cb2