### PR TITLE
Fix editing of planned assignments from general plan

### DIFF
--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -76,6 +76,7 @@ abstract class TransactionsRepository {
     int? necessityId,
     String? necessityLabel,
     bool includedInPeriod = false,
+    int criticality = 0,
   });
 
   Future<List<TransactionItem>> listPlannedByPeriod({
@@ -344,6 +345,7 @@ class SqliteTransactionsRepository implements TransactionsRepository {
     int? necessityId,
     String? necessityLabel,
     bool includedInPeriod = false,
+    int criticality = 0,
   }) async {
     final db = await _db;
     final values = <String, Object?>{
@@ -358,7 +360,7 @@ class SqliteTransactionsRepository implements TransactionsRepository {
       'is_planned': 1,
       'included_in_period': includedInPeriod ? 1 : 0,
       'tags': null,
-      'criticality': 0,
+      'criticality': criticality,
       'necessity_id': necessityId,
       'necessity_label': necessityLabel,
       'reason_id': null,

--- a/lib/ui/planned/planned_master_detail_screen.dart
+++ b/lib/ui/planned/planned_master_detail_screen.dart
@@ -9,8 +9,8 @@ import '../../state/planned_master_providers.dart';
 import '../../state/app_providers.dart';
 import '../../state/planned_providers.dart';
 import '../../utils/formatting.dart';
+import '../../utils/period_utils.dart';
 import 'planned_assign_to_period_sheet.dart';
-import 'planned_add_form.dart';
 import 'planned_master_edit_sheet.dart';
 
 class PlannedMasterDetailScreen extends ConsumerStatefulWidget {
@@ -131,13 +131,12 @@ class _PlannedMasterDetailScreenState
   }
 
   Future<void> _editInstance(PlannedMaster master, TransactionRecord record) async {
-    final type = _plannedTypeFor(master.type);
-    if (type == null) {
-      return;
-    }
-    await showPlannedAddForm(
+    final (anchor1, anchor2) = ref.read(anchorDaysProvider);
+    final period = periodRefForDate(record.date, anchor1, anchor2);
+    await showPlannedAssignToPeriodSheet(
       context,
-      type: type,
+      master: master,
+      initialPeriod: period,
       initialRecord: record,
     );
   }
@@ -246,19 +245,6 @@ class _PlannedMasterDetailScreenState
       return;
     }
     bumpDbTick(ref);
-  }
-
-  PlannedType? _plannedTypeFor(String type) {
-    switch (type) {
-      case 'income':
-        return PlannedType.income;
-      case 'expense':
-        return PlannedType.expense;
-      case 'saving':
-        return PlannedType.saving;
-      default:
-        return null;
-    }
   }
 
 }


### PR DESCRIPTION
## Summary
- reuse the period assignment sheet when editing planned instances so all fields are editable
- preload existing values in the assignment form and update the backing transaction instead of creating a new one
- persist necessity criticality when creating planned instances so the selection is saved

## Testing
- not run (flutter and dart CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d70783826c8326adf3bea17f0e2400