### PR TITLE
feat: add planned quick add flow

### DIFF
--- a/lib/data/repositories/planned_instances_repository.dart
+++ b/lib/data/repositories/planned_instances_repository.dart
@@ -1,0 +1,87 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../db/app_database.dart';
+
+abstract class PlannedInstancesRepository {
+  Future<void> assignMasterToPeriod({
+    required int masterId,
+    required DateTime start,
+    required DateTime endExclusive,
+    required int categoryId,
+    required int amountMinor,
+    required String type,
+    bool includedInPeriod = true,
+    int? necessityId,
+    String? note,
+    String? necessityLabel,
+    DatabaseExecutor? executor,
+  });
+}
+
+class SqlitePlannedInstancesRepository implements PlannedInstancesRepository {
+  SqlitePlannedInstancesRepository({AppDatabase? database})
+      : _database = database ?? AppDatabase.instance;
+
+  final AppDatabase _database;
+
+  Future<Database> get _db async => _database.database;
+
+  @override
+  Future<void> assignMasterToPeriod({
+    required int masterId,
+    required DateTime start,
+    required DateTime endExclusive,
+    required int categoryId,
+    required int amountMinor,
+    required String type,
+    bool includedInPeriod = true,
+    int? necessityId,
+    String? note,
+    String? necessityLabel,
+    DatabaseExecutor? executor,
+  }) async {
+    final db = executor ?? await _db;
+    final normalizedType = type.toLowerCase();
+    final sanitizedNote = note == null || note.trim().isEmpty ? null : note.trim();
+    final instanceDate = _resolveInstanceDate(start, endExclusive);
+    final values = <String, Object?>{
+      'planned_id': masterId,
+      'type': normalizedType,
+      'account_id': 0,
+      'category_id': categoryId,
+      'amount_minor': amountMinor,
+      'date': _formatDate(instanceDate),
+      'time': null,
+      'note': sanitizedNote,
+      'is_planned': 1,
+      'included_in_period': includedInPeriod ? 1 : 0,
+      'tags': null,
+      'criticality': 0,
+      'necessity_id': necessityId,
+      'necessity_label': necessityLabel,
+      'reason_id': null,
+      'reason_label': null,
+      'payout_id': null,
+    };
+    await db.insert('transactions', values);
+  }
+
+  DateTime _resolveInstanceDate(DateTime start, DateTime endExclusive) {
+    final normalizedStart = DateTime(start.year, start.month, start.day);
+    final normalizedEndExclusive = DateTime(
+      endExclusive.year,
+      endExclusive.month,
+      endExclusive.day,
+    );
+    if (normalizedEndExclusive.isAfter(normalizedStart)) {
+      return normalizedStart;
+    }
+    return normalizedStart;
+  }
+
+  String _formatDate(DateTime date) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '${date.year.toString().padLeft(4, '0')}-$month-$day';
+  }
+}

--- a/lib/data/repositories/planned_master_repository.dart
+++ b/lib/data/repositories/planned_master_repository.dart
@@ -97,6 +97,12 @@ abstract class PlannedMasterRepository {
 
   Future<PlannedMaster?> getById(int id);
 
+  Future<PlannedMaster?> findByTitleAndType(
+    String type,
+    String title, {
+    DatabaseExecutor? executor,
+  });
+
   Future<List<PlannedMaster>> listAssignableForPeriod(
     DateTime start,
     DateTime endExclusive, {
@@ -109,6 +115,15 @@ abstract class PlannedMasterRepository {
     int? defaultAmountMinor,
     int? categoryId,
     String? note,
+  });
+
+  Future<PlannedMaster> createMaster({
+    required String type,
+    required String title,
+    required int categoryId,
+    required int amountMinor,
+    String? note,
+    DatabaseExecutor? executor,
   });
 
   Future<bool> update(
@@ -156,6 +171,43 @@ class SqlitePlannedMasterRepository implements PlannedMasterRepository {
   }
 
   @override
+  Future<PlannedMaster> createMaster({
+    required String type,
+    required String title,
+    required int categoryId,
+    required int amountMinor,
+    String? note,
+    DatabaseExecutor? executor,
+  }) async {
+    final db = executor ?? await _db;
+    final normalizedType = _normalizeType(type);
+    final trimmedTitle = title.trim();
+    final sanitizedNote = note == null || note.trim().isEmpty ? null : note.trim();
+    final now = DateTime.now().toUtc();
+    final values = <String, Object?>{
+      'type': normalizedType,
+      'title': trimmedTitle,
+      'default_amount_minor': amountMinor,
+      'category_id': categoryId,
+      'note': sanitizedNote,
+      'archived': 0,
+      'created_at': now.toIso8601String(),
+      'updated_at': now.toIso8601String(),
+    };
+    final id = await db.insert('planned_master', values);
+    final rows = await db.query(
+      'planned_master',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      throw StateError('Failed to create planned master for "$title"');
+    }
+    return PlannedMaster.fromMap(rows.first);
+  }
+
+  @override
   Future<void> delete(int id) async {
     final db = await _db;
     final linked = await db.rawQuery(
@@ -193,6 +245,30 @@ class SqlitePlannedMasterRepository implements PlannedMasterRepository {
       orderBy: 'archived ASC, title COLLATE NOCASE ASC, id ASC',
     );
     return rows.map(PlannedMaster.fromMap).toList();
+  }
+
+  @override
+  Future<PlannedMaster?> findByTitleAndType(
+    String type,
+    String title, {
+    DatabaseExecutor? executor,
+  }) async {
+    final db = executor ?? await _db;
+    final normalizedType = _normalizeType(type);
+    final normalizedTitle = title.trim().toLowerCase();
+    if (normalizedTitle.isEmpty) {
+      return null;
+    }
+    final rows = await db.query(
+      'planned_master',
+      where: 'type = ? AND archived = 0 AND LOWER(title) = ?',
+      whereArgs: [normalizedType, normalizedTitle],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return PlannedMaster.fromMap(rows.first);
   }
 
   @override

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -13,6 +13,7 @@ import '../../state/planned_providers.dart';
 import '../../state/db_refresh.dart';
 import '../../utils/formatting.dart';
 import '../../utils/ru_plural.dart';
+import '../planned/planned_quick_add_sheet.dart';
 import '../planned/planned_sheet.dart';
 import '../payouts/payout_edit_sheet.dart';
 import 'daily_limit_sheet.dart';
@@ -599,6 +600,30 @@ class _PlannedOverview extends StatelessWidget {
   Widget build(BuildContext context) {
     final payoutAsync = ref.watch(payoutForSelectedPeriodProvider);
     final plannedRemainderAsync = ref.watch(plannedRemainderForPeriodProvider);
+    Future<void> openQuickAdd(BuildContext context, PlannedType type) async {
+      final sheetNotifier = ref.read(isSheetOpenProvider.notifier);
+      sheetNotifier.state = true;
+      try {
+        final period = ref.read(selectedPeriodRefProvider);
+        final result = await showPlannedQuickAddForm(
+          context,
+          ref: ref,
+          type: switch (type) {
+            PlannedType.income => 'income',
+            PlannedType.expense => 'expense',
+            PlannedType.saving => 'saving',
+          },
+          period: period,
+        );
+        if (result == true && context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('План добавлен')),
+          );
+        }
+      } finally {
+        sheetNotifier.state = false;
+      }
+    }
     return payoutAsync.when(
       data: (payout) {
         if (payout == null) {
@@ -676,6 +701,12 @@ class _PlannedOverview extends StatelessWidget {
                 loading: () => const Text('Загрузка…'),
                 error: (error, _) => Text('Ошибка: $error'),
               ),
+              trailing: TextButton.icon(
+                key: const Key('planned_add_income'),
+                onPressed: () => openQuickAdd(context, PlannedType.income),
+                icon: const Icon(Icons.add),
+                label: const Text('Добавить'),
+              ),
               onTap: () => onOpenPlanned(PlannedType.income),
             ),
             const Divider(height: 0),
@@ -687,6 +718,12 @@ class _PlannedOverview extends StatelessWidget {
                 loading: () => const Text('Загрузка…'),
                 error: (error, _) => Text('Ошибка: $error'),
               ),
+              trailing: TextButton.icon(
+                key: const Key('planned_add_expense'),
+                onPressed: () => openQuickAdd(context, PlannedType.expense),
+                icon: const Icon(Icons.add),
+                label: const Text('Добавить'),
+              ),
               onTap: () => onOpenPlanned(PlannedType.expense),
             ),
             const Divider(height: 0),
@@ -697,6 +734,12 @@ class _PlannedOverview extends StatelessWidget {
                 data: (value) => Text(formatCurrencyMinor(value)),
                 loading: () => const Text('Загрузка…'),
                 error: (error, _) => Text('Ошибка: $error'),
+              ),
+              trailing: TextButton.icon(
+                key: const Key('planned_add_saving'),
+                onPressed: () => openQuickAdd(context, PlannedType.saving),
+                icon: const Icon(Icons.add),
+                label: const Text('Добавить'),
               ),
               onTap: () => onOpenPlanned(PlannedType.saving),
             ),

--- a/lib/ui/planned/planned_quick_add_sheet.dart
+++ b/lib/ui/planned/planned_quick_add_sheet.dart
@@ -1,0 +1,422 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/category.dart';
+import '../../data/repositories/necessity_repository.dart' as necessity_repo;
+import '../../state/app_providers.dart';
+import '../../state/db_refresh.dart';
+import '../../state/planned_master_providers.dart';
+import '../../state/planned_providers.dart';
+import '../../utils/period_utils.dart';
+
+Future<bool?> showPlannedQuickAddForm(
+  BuildContext context, {
+  required WidgetRef ref,
+  required String type,
+  required PeriodRef period,
+}) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (_) => _PlannedQuickAddSheet(
+      type: type,
+      period: period,
+    ),
+  );
+}
+
+class _PlannedQuickAddSheet extends ConsumerStatefulWidget {
+  const _PlannedQuickAddSheet({
+    required this.type,
+    required this.period,
+  });
+
+  final String type;
+  final PeriodRef period;
+
+  @override
+  ConsumerState<_PlannedQuickAddSheet> createState() =>
+      _PlannedQuickAddSheetState();
+}
+
+class _PlannedQuickAddSheetState extends ConsumerState<_PlannedQuickAddSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _titleController;
+  late final TextEditingController _amountController;
+  late final TextEditingController _noteController;
+  int? _selectedCategoryId;
+  int? _selectedNecessityId;
+  bool _included = true;
+  bool _reuseExisting = true;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController();
+    _amountController = TextEditingController();
+    _noteController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _amountController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final viewInsets = MediaQuery.of(context).viewInsets.bottom;
+    final sheetHeight = MediaQuery.of(context).size.height * 0.9;
+    final categoryType = _categoryTypeFor(widget.type);
+    final AsyncValue<List<Category>> categoriesAsync;
+    if (categoryType != null) {
+      categoriesAsync = ref.watch(categoriesByTypeProvider(categoryType));
+    } else {
+      categoriesAsync = const AsyncValue<List<Category>>.data(<Category>[]);
+    }
+    final AsyncValue<List<necessity_repo.NecessityLabel>> necessityLabelsAsync;
+    if (widget.type == 'expense') {
+      necessityLabelsAsync = ref.watch(necessityLabelsFutureProvider);
+    } else {
+      necessityLabelsAsync =
+          const AsyncValue<List<necessity_repo.NecessityLabel>>.data(
+        <necessity_repo.NecessityLabel>[],
+      );
+    }
+
+    final categories = categoriesAsync.maybeWhen<List<Category>>(
+      data: (items) {
+        final filtered = [
+          for (final item in items)
+            if (!item.isGroup && !item.isArchived && item.id != null) item,
+        ];
+        filtered.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        if (_selectedCategoryId == null && filtered.isNotEmpty) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _selectedCategoryId = filtered.first.id;
+            });
+          });
+        }
+        return filtered;
+      },
+      orElse: () => const [],
+    );
+    final categoriesError =
+        categoriesAsync is AsyncError ? categoriesAsync.error : null;
+    final canSubmit =
+        !_isSaving && categories.isNotEmpty && _selectedCategoryId != null;
+
+    return SizedBox(
+      height: sheetHeight + viewInsets,
+      child: Padding(
+        padding: EdgeInsets.only(bottom: viewInsets),
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Center(
+                      child: Container(
+                        width: 36,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.outlineVariant,
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      _titleForType(widget.type),
+                      style: theme.textTheme.titleMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _titleController,
+                      decoration: const InputDecoration(
+                        labelText: 'Название',
+                      ),
+                      textCapitalization: TextCapitalization.sentences,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Укажите название';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    if (categoriesAsync.isLoading)
+                      const LinearProgressIndicator()
+                    else if (categoriesError != null)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: Text(
+                          'Не удалось загрузить категории: $categoriesError',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
+                      )
+                    else if (categories.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: Text(
+                          'Добавьте категорию, чтобы создать план.',
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      )
+                    else
+                      DropdownButtonFormField<int>(
+                        value: _selectedCategoryId,
+                        items: [
+                          for (final category in categories)
+                            DropdownMenuItem<int>(
+                              value: category.id,
+                              child: Text(category.name),
+                            ),
+                        ],
+                        onChanged: _isSaving
+                            ? null
+                            : (value) {
+                                setState(() => _selectedCategoryId = value);
+                              },
+                        decoration: const InputDecoration(
+                          labelText: 'Категория',
+                        ),
+                        validator: (value) {
+                          if (value == null) {
+                            return 'Выберите категорию';
+                          }
+                          return null;
+                        },
+                      ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _amountController,
+                      decoration: const InputDecoration(
+                        labelText: 'Сумма',
+                        prefixText: '₽ ',
+                      ),
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.digitsOnly,
+                      ],
+                      validator: (value) {
+                        final raw = value?.trim() ?? '';
+                        if (raw.isEmpty) {
+                          return 'Укажите сумму';
+                        }
+                        final parsed = int.tryParse(raw);
+                        if (parsed == null || parsed <= 0) {
+                          return 'Сумма должна быть больше 0';
+                        }
+                        return null;
+                      },
+                    ),
+                    if (widget.type == 'expense') ...[
+                      const SizedBox(height: 12),
+                      necessityLabelsAsync.when(
+                        data: (labels) {
+                          return DropdownButtonFormField<int?>(
+                            value: _selectedNecessityId,
+                            items: [
+                              const DropdownMenuItem<int?>(
+                                value: null,
+                                child: Text('Без необходимости'),
+                              ),
+                              for (final label in labels)
+                                DropdownMenuItem<int?>(
+                                  value: label.id,
+                                  child: Text(label.name),
+                                ),
+                            ],
+                            onChanged: _isSaving
+                                ? null
+                                : (value) {
+                                    setState(() => _selectedNecessityId = value);
+                                  },
+                            decoration: const InputDecoration(
+                              labelText: 'Критичность/необходимость',
+                            ),
+                          );
+                        },
+                        loading: () => const LinearProgressIndicator(),
+                        error: (error, _) => Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: Text(
+                            'Не удалось загрузить ярлыки: $error',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.error,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 12),
+                    CheckboxListTile(
+                      value: _included,
+                      onChanged: _isSaving
+                          ? null
+                          : (value) {
+                              setState(() => _included = value ?? true);
+                            },
+                      title: const Text('Учитывать в расчёте'),
+                      contentPadding: EdgeInsets.zero,
+                      controlAffinity: ListTileControlAffinity.leading,
+                    ),
+                    CheckboxListTile(
+                      value: _reuseExisting,
+                      onChanged: _isSaving
+                          ? null
+                          : (value) {
+                              setState(() => _reuseExisting = value ?? true);
+                            },
+                      title: const Text('Использовать уже существующий, если есть'),
+                      contentPadding: EdgeInsets.zero,
+                      controlAffinity: ListTileControlAffinity.leading,
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _noteController,
+                      decoration: const InputDecoration(
+                        labelText: 'Примечание',
+                      ),
+                      textCapitalization: TextCapitalization.sentences,
+                      maxLines: 3,
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                boxShadow: [
+                  BoxShadow(
+                    color: theme.colorScheme.shadow.withOpacity(0.1),
+                    blurRadius: 8,
+                  ),
+                ],
+              ),
+              child: Row(
+                children: [
+                  TextButton(
+                    onPressed: _isSaving
+                        ? null
+                        : () => Navigator.of(context).pop(false),
+                    child: const Text('Отмена'),
+                  ),
+                  const Spacer(),
+                  FilledButton.icon(
+                    onPressed: canSubmit ? _handleSubmit : null,
+                    icon: _isSaving
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.check),
+                    label: const Text('Сохранить'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  CategoryType? _categoryTypeFor(String type) {
+    switch (type) {
+      case 'income':
+        return CategoryType.income;
+      case 'expense':
+        return CategoryType.expense;
+      case 'saving':
+        return CategoryType.saving;
+      default:
+        return null;
+    }
+  }
+
+  String _titleForType(String type) {
+    switch (type) {
+      case 'income':
+        return 'Быстрое добавление дохода';
+      case 'saving':
+        return 'Быстрое добавление сбережения';
+      case 'expense':
+      default:
+        return 'Быстрое добавление расхода';
+    }
+  }
+
+  Future<void> _handleSubmit() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final categoryId = _selectedCategoryId;
+    if (categoryId == null) {
+      return;
+    }
+    final amountRub = int.tryParse(_amountController.text.trim());
+    if (amountRub == null || amountRub <= 0) {
+      return;
+    }
+    final title = _titleController.text.trim();
+    final noteText = _noteController.text.trim();
+    final note = noteText.isEmpty ? null : noteText;
+    final necessityId = widget.type == 'expense' ? _selectedNecessityId : null;
+
+    setState(() => _isSaving = true);
+    try {
+      final facade = ref.read(plannedFacadeProvider);
+      await facade.createMasterAndAssignToCurrentPeriod(
+        type: widget.type,
+        title: title,
+        categoryId: categoryId,
+        amountMinor: amountRub * 100,
+        period: widget.period,
+        includedInPeriod: _included,
+        necessityId: necessityId,
+        note: note,
+        reuseExisting: _reuseExisting,
+      );
+      bumpDbTick(ref);
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(true);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Не удалось сохранить план: $error')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a quick-add bottom sheet for planned income, expense, and saving items from the home screen
- introduce a facade and repository helpers to create planned masters and assign instances atomically with optional deduplication
- refresh planned data providers to deliver period-aware lists and totals that react to database updates

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70a60529c8326a79ebb7c44687a5d