### PR TITLE
Fix provider mutation when initializing review screen from operations

### DIFF
--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -55,15 +55,22 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
     selectedDate = ValueNotifier(entryState.selectedDate);
     final initialAmountMinor = (entryState.amount * 100).round();
     amountMinor = ValueNotifier(initialAmountMinor);
-    final initialAccountId = entryState.accountId ?? entryState.editingRecord?.accountId;
+    final initialAccountId =
+        entryState.accountId ?? entryState.editingRecord?.accountId;
     if (initialAccountId != null) {
       _accountInitialized = true;
     }
-    selectedAccountId = ValueNotifier<int>(initialAccountId ?? _kUnselectedAccountId);
-    if (initialAccountId != null) {
-      ref
-          .read(entryFlowControllerProvider.notifier)
-          .setAccount(initialAccountId);
+    selectedAccountId =
+        ValueNotifier<int>(initialAccountId ?? _kUnselectedAccountId);
+    if (initialAccountId != null && entryState.accountId == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+        ref
+            .read(entryFlowControllerProvider.notifier)
+            .setAccount(initialAccountId);
+      });
     }
     _reasonValidationError = false;
     _entryFlowSubscription = ref.listenManual<EntryFlowState>(


### PR DESCRIPTION
## Summary
- prevent the review screen from mutating the entry flow provider during initState
- defer syncing the initial account to the provider until after the first frame when needed

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70d23568483269b2535fd3f9e5e2e