### PR TITLE
Allow decimal amounts when editing planned templates

### DIFF
--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -220,7 +220,8 @@ class _PlannedMasterEditFormState
           const SizedBox(height: 12),
           TextFormField(
             controller: _amountController,
-            keyboardType: TextInputType.number,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
             decoration: const InputDecoration(
               labelText: 'Сумма ₽ *',
               prefixText: '₽ ',
@@ -231,11 +232,8 @@ class _PlannedMasterEditFormState
               if (text == null || text.isEmpty) {
                 return 'Введите сумму';
               }
-              final digitsOnly = RegExp(r'^\d+$');
-              if (!digitsOnly.hasMatch(text)) {
-                return 'Введите целое число';
-              }
-              final parsed = int.tryParse(text);
+              final normalized = text.replaceAll(' ', '').replaceAll(',', '.');
+              final parsed = double.tryParse(normalized);
               if (parsed == null) {
                 return 'Некорректная сумма';
               }
@@ -672,19 +670,11 @@ class _PlannedMasterEditFormState
   }
 
   bool _hasValidAmount(String raw) {
-    final text = raw.trim();
-    if (text.isEmpty) {
+    final amountMinor = _parseAmountMinorOrNull(raw);
+    if (amountMinor == null) {
       return false;
     }
-    final digitsOnly = RegExp(r'^\d+$');
-    if (!digitsOnly.hasMatch(text)) {
-      return false;
-    }
-    final parsed = int.tryParse(text);
-    if (parsed == null) {
-      return false;
-    }
-    return parsed > 0;
+    return amountMinor > 0;
   }
 
   int? _parseAmountMinorOrNull(String raw) {
@@ -692,15 +682,12 @@ class _PlannedMasterEditFormState
     if (text.isEmpty) {
       return null;
     }
-    final digitsOnly = RegExp(r'^\d+$');
-    if (!digitsOnly.hasMatch(text)) {
-      return null;
-    }
-    final parsed = int.tryParse(text);
+    final normalized = text.replaceAll(' ', '').replaceAll(',', '.');
+    final parsed = double.tryParse(normalized);
     if (parsed == null || parsed <= 0) {
       return null;
     }
-    return parsed * 100;
+    return (parsed * 100).round();
   }
 
   void _updateDirty() {


### PR DESCRIPTION
## Summary
- allow entering decimal values in the planned template amount field
- parse and validate monetary input consistently so fractional values are preserved when saving

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d71a386f548326bef9e817a54bd1aa