### PR TITLE
Fix provider update timing when editing planned period

### DIFF
--- a/lib/ui/planned/planned_assign_to_period_sheet.dart
+++ b/lib/ui/planned/planned_assign_to_period_sheet.dart
@@ -82,7 +82,12 @@ class _PlannedAssignToPeriodFormState
     final master = widget.master;
     final initialPeriod = widget.initialPeriod;
     if (initialPeriod != null) {
-      ref.read(selectedPeriodRefProvider.notifier).state = initialPeriod;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+        ref.read(selectedPeriodRefProvider.notifier).state = initialPeriod;
+      });
     }
     final existing = widget.initialRecord;
     if (existing != null) {


### PR DESCRIPTION
## Summary
- delay updating the selected period provider until after the first frame to avoid modifying providers during build

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d71be4a9908326989f88458a0ca60d