### PR TITLE
Require necessity selection for new planned templates

### DIFF
--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -281,10 +281,8 @@ class _PlannedMasterEditFormState
               const SizedBox(width: 12),
               Expanded(
                 child: FilledButton(
-                  onPressed: _isSaving || !_isAmountValid ||
-                          (_isEditMode && !_isDirty)
-                      ? null
-                      : _submit,
+                  onPressed:
+                      _isSaving || !_isAmountValid || !_isDirty ? null : _submit,
                   child: _isSaving
                       ? const SizedBox(
                           height: 18,


### PR DESCRIPTION
## Summary
- disable saving a new planned template until all required fields are filled, including necessity selection for expenses

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7b95aeb808326b31acbdd343aa16a