### PR TITLE
Require necessity selection for new general plan templates

### DIFF
--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -290,7 +290,11 @@ class _PlannedMasterEditFormState
                       const SizedBox(width: 12),
                       Expanded(
                         child: FilledButton(
-                          onPressed: _isSaving || !_isAmountValid ||
+                          onPressed: _isSaving ||
+                                  !_isAmountValid ||
+                                  (!_isEditMode &&
+                                      _isExpense &&
+                                      _selectedNecessityId == null) ||
                                   (_isEditMode && !_isDirty)
                               ? null
                               : _submit,


### PR DESCRIPTION
## Summary
- disable the save action for new general plan templates until a necessity label is selected for expenses

## Testing
- not run (Flutter is not installed in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ba5a2a78832697b6f1cba44140fc