### PR TITLE
Refactor settings screen callouts

### DIFF
--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -112,6 +112,12 @@ final payoutSuggestedTypeProvider = Provider<PayoutType>((ref) {
 String payoutTypeLabel(PayoutType type) =>
     type == PayoutType.salary ? 'Зарплата' : 'Аванс';
 
+final payoutsHistoryProvider = FutureProvider<List<Payout>>((ref) {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(payoutsRepoProvider);
+  return repository.getHistory(30);
+});
+
 /// (start, endExclusive) для выбранного периода (конкретный месяц)
 final periodBoundsProvider = Provider<(DateTime start, DateTime endExclusive)>((ref) {
   final (a1, a2) = ref.watch(anchorDaysProvider);

--- a/lib/ui/settings/settings_placeholder.dart
+++ b/lib/ui/settings/settings_placeholder.dart
@@ -6,13 +6,14 @@ import '../../data/models/payout.dart';
 import '../../state/app_providers.dart';
 import '../../state/budget_providers.dart';
 import '../../state/db_refresh.dart';
-import '../../utils/ref_postframe.dart';
-import '../payouts/payout_edit_sheet.dart';
 import 'backups_settings_screen.dart';
 import 'categories_manage_screen.dart';
 import 'necessity_settings_screen.dart';
 import 'reasons_settings_screen.dart';
 import '../home/daily_limit_sheet.dart';
+import '../payouts/payout_edit_sheet.dart';
+import '../../utils/formatting.dart';
+import '../../utils/ref_postframe.dart';
 import '../../routing/app_router.dart';
 
 class SettingsPlaceholder extends ConsumerStatefulWidget {
@@ -23,307 +24,21 @@ class SettingsPlaceholder extends ConsumerStatefulWidget {
 }
 
 class _SettingsPlaceholderState extends ConsumerState<SettingsPlaceholder> {
-  String _selectedCurrency = '₽';
-
   @override
   Widget build(BuildContext context) {
-    final periods = ref.watch(periodsProvider);
-    final activePeriod = ref.watch(activePeriodProvider);
-    final controller = ref.read(activePeriodProvider.notifier);
-    final themeMode = ref.watch(themeModeProvider);
-    final themeModeNotifier = ref.read(themeModeProvider.notifier);
-
-    final suggestedType = ref.watch(payoutSuggestedTypeProvider);
-    final generalPayoutLabel =
-        'Добавить выплату (по периоду: ${payoutTypeLabel(suggestedType)})';
-
     return Scaffold(
       appBar: AppBar(title: const Text('Настройки')),
       body: ListView(
-        padding: const EdgeInsets.all(24),
-        children: [
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Период бюджета по умолчанию',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 12),
-                  DropdownButtonFormField<String>(
-                    value: activePeriod.id,
-                    items: [
-                      for (final period in periods)
-                        DropdownMenuItem(
-                          value: period.id,
-                          child: Text(period.title),
-                        ),
-                    ],
-                    onChanged: (value) {
-                      if (value != null) {
-                        controller.setActive(value);
-                      }
-                    },
-                  ),
-                  const SizedBox(height: 12),
-                  const Text(
-                    'В следующих спринтах можно будет выбрать кастомные даты начала и окончания периода.',
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 24),
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Валюта приложения',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 12),
-                  DropdownButtonFormField<String>(
-                    value: _selectedCurrency,
-                    items: const [
-                      DropdownMenuItem(value: '₽', child: Text('Российский рубль (₽)')),
-                      DropdownMenuItem(value: '€', child: Text('Евро (€)')),
-                      DropdownMenuItem(value: r'$', child: Text(r'Доллар США ($)')),
-                    ],
-                    onChanged: (value) {
-                      if (value != null) {
-                        setState(() => _selectedCurrency = value);
-                      }
-                    },
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Сейчас используется $_selectedCurrency. Позже валюта будет влиять на формат отображения и синхронизацию.',
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 24),
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Тема',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 12),
-                  SegmentedButton<ThemeMode>(
-                    segments: const [
-                      ButtonSegment(
-                        value: ThemeMode.system,
-                        label: Text('Системная'),
-                      ),
-                      ButtonSegment(
-                        value: ThemeMode.light,
-                        label: Text('Светлая'),
-                      ),
-                      ButtonSegment(
-                        value: ThemeMode.dark,
-                        label: Text('Тёмная'),
-                      ),
-                    ],
-                    selected: {themeMode},
-                    onSelectionChanged: (modes) {
-                      if (modes.isEmpty) {
-                        return;
-                      }
-
-                      final selectedMode = modes.first;
-                      if (selectedMode == themeModeNotifier.state) {
-                        return;
-                      }
-
-                      WidgetsBinding.instance.addPostFrameCallback((_) {
-                        if (!mounted) {
-                          return;
-                        }
-                        themeModeNotifier.state = selectedMode;
-                      });
-                    },
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 24),
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Выплаты',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 12),
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      ListTile(
-                        contentPadding: EdgeInsets.zero,
-                        leading: const Icon(Icons.payments_outlined),
-                        title: Text(generalPayoutLabel),
-                        subtitle: const Text(
-                          'Тип выбирается автоматически по текущему полупериоду.',
-                        ),
-                        onTap: () => _showPayoutSheet(context),
-                      ),
-                      const Divider(height: 0),
-                      ListTile(
-                        contentPadding: EdgeInsets.zero,
-                        leading: const Icon(Icons.trending_up_outlined),
-                        title: const Text('Добавить аванс'),
-                        subtitle: const Text('Тип фиксирован как аванс.'),
-                        onTap: () =>
-                            _showPayoutSheet(context, forcedType: PayoutType.advance),
-                      ),
-                      const Divider(height: 0),
-                      ListTile(
-                        contentPadding: EdgeInsets.zero,
-                        leading: const Icon(Icons.attach_money_outlined),
-                        title: const Text('Добавить зарплату'),
-                        subtitle: const Text('Тип фиксирован как зарплата.'),
-                        onTap: () =>
-                            _showPayoutSheet(context, forcedType: PayoutType.salary),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 24),
-          Card(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ListTile(
-                  title: const Text('Резервные копии'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => const BackupsSettingsScreen(),
-                      ),
-                    );
-                  },
-                ),
-                const Divider(height: 0),
-                ListTile(
-                  title: const Text('Настройки категорий'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => const CategoriesManageScreen(),
-                      ),
-                    );
-                  },
-                  onLongPress: () => _restoreDefaultCategories(context),
-                ),
-                const Divider(height: 0),
-                ListTile(
-                  title: const Text('Критичность/Необходимость'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => const NecessitySettingsScreen(),
-                      ),
-                    );
-                  },
-                ),
-                const Divider(height: 0),
-                ListTile(
-                  title: const Text('Причины расходов'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => const ReasonsSettingsScreen(),
-                      ),
-                    );
-                  },
-                ),
-                const Divider(height: 0),
-                ListTile(
-                  title: const Text('Общий план'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => context.pushNamed(RouteNames.plannedLibrary),
-                ),
-              ],
-            ),
-          ),
+        padding: const EdgeInsets.all(16),
+        children: const [
+          ThemeCallout(),
+          SizedBox(height: 12),
+          PayoutsSettingsSection(),
+          SizedBox(height: 12),
+          _OtherSettingsCard(),
         ],
       ),
     );
-  }
-
-  Future<void> _showPayoutSheet(
-    BuildContext context, {
-    PayoutType? forcedType,
-  }) async {
-    final tickBefore = ref.read(dbTickProvider);
-    await showPayoutForSelectedPeriod(
-      context,
-      forcedType: forcedType,
-    );
-
-    if (!mounted) {
-      return;
-    }
-
-    final tickAfter = ref.read(dbTickProvider);
-    if (tickAfter == tickBefore) {
-      return;
-    }
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Выплата добавлена')),
-    );
-    final dailyLimitValue = ref
-        .read(dailyLimitProvider)
-        .maybeWhen(data: (value) => value ?? 0, orElse: () => 0);
-    if (dailyLimitValue == 0) {
-      ref.postFrame(() {
-        if (!mounted) {
-          return;
-        }
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Назначьте дневной лимит'),
-            action: SnackBarAction(
-              label: 'Задать',
-              onPressed: () {
-                showEditDailyLimitSheet(context, ref).then((saved) {
-                  if (!mounted || !saved) {
-                    return;
-                  }
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Лимит сохранён')),
-                  );
-                });
-              },
-            ),
-          ),
-        );
-      });
-    }
   }
 
   Future<void> _restoreDefaultCategories(BuildContext context) async {
@@ -374,5 +89,385 @@ class _SettingsPlaceholderState extends ConsumerState<SettingsPlaceholder> {
         SnackBar(content: Text('Не удалось восстановить: $error')),
       );
     }
+  }
+}
+
+class _OtherSettingsCard extends ConsumerWidget {
+  const _OtherSettingsCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Card(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            title: const Text('Резервные копии'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const BackupsSettingsScreen(),
+                ),
+              );
+            },
+          ),
+          const Divider(height: 0),
+          ListTile(
+            title: const Text('Настройки категорий'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const CategoriesManageScreen(),
+                ),
+              );
+            },
+            onLongPress: () {
+              final state =
+                  context.findAncestorStateOfType<_SettingsPlaceholderState>();
+              state?._restoreDefaultCategories(context);
+            },
+          ),
+          const Divider(height: 0),
+          ListTile(
+            title: const Text('Критичность/Необходимость'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const NecessitySettingsScreen(),
+                ),
+              );
+            },
+          ),
+          const Divider(height: 0),
+          ListTile(
+            title: const Text('Причины расходов'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const ReasonsSettingsScreen(),
+                ),
+              );
+            },
+          ),
+          const Divider(height: 0),
+          ListTile(
+            title: const Text('Общий план'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.pushNamed(RouteNames.plannedLibrary),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ThemeCallout extends ConsumerWidget {
+  const ThemeCallout({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(themeModeProvider);
+    void setMode(ThemeMode target) {
+      if (target == mode) {
+        return;
+      }
+      ref.read(themeModeProvider.notifier).state = target;
+    }
+
+    const items = <({ThemeMode mode, IconData icon, String label})>[
+      (mode: ThemeMode.system, icon: Icons.settings_brightness, label: 'Системная'),
+      (mode: ThemeMode.light, icon: Icons.light_mode, label: 'Светлая'),
+      (mode: ThemeMode.dark, icon: Icons.dark_mode, label: 'Тёмная'),
+    ];
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Тема', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final showLabels = constraints.maxWidth >= 360;
+                final minWidth = showLabels ? 96.0 : 48.0;
+                final padding = showLabels
+                    ? const EdgeInsets.symmetric(horizontal: 12, vertical: 6)
+                    : const EdgeInsets.symmetric(horizontal: 8, vertical: 6);
+
+                return ToggleButtons(
+                  isSelected: [for (final item in items) item.mode == mode],
+                  onPressed: (index) => setMode(items[index].mode),
+                  constraints: BoxConstraints(minHeight: 36, minWidth: minWidth),
+                  borderRadius: BorderRadius.circular(12),
+                  visualDensity: VisualDensity.compact,
+                  children: [
+                    for (final item in items)
+                      Tooltip(
+                        triggerMode: TooltipTriggerMode.longPress,
+                        message: item.label,
+                        child: Padding(
+                          padding: padding,
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(item.icon, size: 18),
+                              if (showLabels) ...[
+                                const SizedBox(width: 6),
+                                ConstrainedBox(
+                                  constraints: const BoxConstraints(maxWidth: 100),
+                                  child: Text(
+                                    item.label,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class PayoutsSettingsSection extends ConsumerWidget {
+  const PayoutsSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final payoutsAsync = ref.watch(payoutsHistoryProvider);
+    final accountsAsync = ref.watch(accountsDbProvider);
+    final accountNames = accountsAsync.maybeWhen(
+      data: (accounts) => {
+        for (final account in accounts)
+          if (account.id != null) account.id!: account.name,
+      },
+      orElse: () => const <int, String>{},
+    );
+
+    Future<void> addPayout() async {
+      final tickBefore = ref.read(dbTickProvider);
+      await showPayoutForSelectedPeriod(context);
+      if (!context.mounted) {
+        return;
+      }
+      final tickAfter = ref.read(dbTickProvider);
+      if (tickAfter == tickBefore) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Выплата добавлена')),
+      );
+      final dailyLimitValue = ref
+          .read(dailyLimitProvider)
+          .maybeWhen(data: (value) => value ?? 0, orElse: () => 0);
+      if (dailyLimitValue == 0) {
+        final localContext = context;
+        ref.postFrame(() {
+          if (!localContext.mounted) {
+            return;
+          }
+          ScaffoldMessenger.of(localContext).showSnackBar(
+            SnackBar(
+              content: const Text('Назначьте дневной лимит'),
+              action: SnackBarAction(
+                label: 'Задать',
+                onPressed: () {
+                  showEditDailyLimitSheet(localContext, ref).then((saved) {
+                    if (!localContext.mounted || !saved) {
+                      return;
+                    }
+                    ScaffoldMessenger.of(localContext).showSnackBar(
+                      const SnackBar(content: Text('Лимит сохранён')),
+                    );
+                  });
+                },
+              ),
+            ),
+          );
+        });
+      }
+    }
+
+    Future<void> onMenuAction(String action, Payout payout) async {
+      switch (action) {
+        case 'edit':
+          {
+            final tickBefore = ref.read(dbTickProvider);
+            await showPayoutEditSheet(
+              context,
+              initial: payout,
+            );
+            if (!context.mounted) {
+              return;
+            }
+            final tickAfter = ref.read(dbTickProvider);
+            if (tickAfter == tickBefore) {
+              return;
+            }
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Изменения применены')),
+            );
+            break;
+          }
+        case 'delete':
+          {
+            final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (dialogContext) {
+                    return AlertDialog(
+                      title: const Text('Удалить выплату?'),
+                      content: const Text('Это действие нельзя отменить.'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(dialogContext).pop(false),
+                          child: const Text('Отмена'),
+                        ),
+                        FilledButton(
+                          onPressed: () => Navigator.of(dialogContext).pop(true),
+                          child: const Text('Удалить'),
+                        ),
+                      ],
+                    );
+                  },
+                ) ??
+                false;
+            if (!confirmed) {
+              return;
+            }
+            final id = payout.id;
+            if (id == null) {
+              return;
+            }
+            await ref.read(payoutsRepoProvider).delete(id);
+            bumpDbTick(ref);
+            if (!context.mounted) {
+              return;
+            }
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Выплата удалена')),
+            );
+            break;
+          }
+        default:
+          break;
+      }
+    }
+
+    Future<void> showTileMenu(BuildContext tileContext, Payout payout) async {
+      final renderBox = tileContext.findRenderObject() as RenderBox?;
+      final overlay = Overlay.of(tileContext).context.findRenderObject() as RenderBox;
+      if (renderBox == null) {
+        return;
+      }
+      final position = RelativeRect.fromRect(
+        Rect.fromLTWH(
+          renderBox.localToGlobal(Offset.zero, ancestor: overlay).dx,
+          renderBox.localToGlobal(Offset.zero, ancestor: overlay).dy,
+          renderBox.size.width,
+          renderBox.size.height,
+        ),
+        Offset.zero & overlay.size,
+      );
+      final selection = await showMenu<String>(
+        context: tileContext,
+        position: position,
+        items: const [
+          PopupMenuItem(value: 'edit', child: Text('Редактировать')),
+          PopupMenuItem(value: 'delete', child: Text('Удалить')),
+        ],
+      );
+      if (selection != null) {
+        await onMenuAction(selection, payout);
+      }
+    }
+
+    Widget buildHistory(List<Payout> payouts) {
+      if (payouts.isEmpty) {
+        return const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: Text('Пока нет сохранённых выплат'),
+        );
+      }
+      return ListView.separated(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemBuilder: (context, index) {
+          final payout = payouts[index];
+          final accountName = payout.accountId != null
+              ? accountNames[payout.accountId!] ?? 'Без счёта'
+              : 'Без счёта';
+          final dateLabel = formatDayMonth(payout.date);
+          return Builder(
+            builder: (tileContext) {
+              return ListTile(
+                dense: true,
+                visualDensity: VisualDensity.compact,
+                leading: Icon(
+                  payout.type == PayoutType.advance
+                      ? Icons.payments_outlined
+                      : Icons.attach_money_outlined,
+                ),
+                title: Text(formatCurrencyMinor(payout.amountMinor)),
+                subtitle: Text(
+                  '$dateLabel • $accountName • ${payoutTypeLabel(payout.type)}',
+                ),
+                trailing: PopupMenuButton<String>(
+                  tooltip: 'Действия',
+                  onSelected: (value) => onMenuAction(value, payout),
+                  itemBuilder: (context) => const [
+                    PopupMenuItem(value: 'edit', child: Text('Редактировать')),
+                    PopupMenuItem(value: 'delete', child: Text('Удалить')),
+                  ],
+                ),
+                onLongPress: () => showTileMenu(tileContext, payout),
+              );
+            },
+          );
+        },
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemCount: payouts.length,
+      );
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text('Выплаты', style: Theme.of(context).textTheme.titleMedium),
+                const Spacer(),
+                FilledButton.icon(
+                  icon: const Icon(Icons.add),
+                  label: const Text('Добавить выплату'),
+                  onPressed: addPayout,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            payoutsAsync.when(
+              data: buildHistory,
+              loading: () => const LinearProgressIndicator(minHeight: 2),
+              error: (error, _) => Text('Не удалось загрузить выплаты: $error'),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- replace the legacy settings callouts with a compact theme toggle and payouts history section
- add a reusable payoutsHistoryProvider powered by the existing repository
- keep navigation callouts while removing unused budget period and currency controls

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f8abde1483269aed55c78a381015