### PR TITLE
Fix ToggleButtons usage for compatibility

### DIFF
--- a/lib/ui/settings/settings_placeholder.dart
+++ b/lib/ui/settings/settings_placeholder.dart
@@ -205,7 +205,6 @@ class ThemeCallout extends ConsumerWidget {
                   onPressed: (index) => setMode(items[index].mode),
                   constraints: BoxConstraints(minHeight: 36, minWidth: minWidth),
                   borderRadius: BorderRadius.circular(12),
-                  visualDensity: VisualDensity.compact,
                   children: [
                     for (final item in items)
                       Tooltip(


### PR DESCRIPTION
## Summary
- remove the unsupported `visualDensity` parameter from the settings theme toggle to restore compatibility with the current Flutter SDK

## Testing
- flutter analyze *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d80d5abc5c8326bff634141955c38b