### PR TITLE
Simplify planned expenses callout and planned pool providers

### DIFF
--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -313,7 +313,7 @@ final periodBudgetMinorProvider = FutureProvider<int>((ref) async {
   return dailyLimit * remainingDays;
 });
 
-final plannedPoolMinorProvider = FutureProvider<int>((ref) async {
+final plannedPoolBaseProvider = FutureProvider<int>((ref) async {
   ref.watch(dbTickProvider);
   final payout = await ref.watch(payoutForSelectedPeriodProvider.future);
   if (payout == null) {

--- a/lib/ui/planned/planned_master_detail_screen.dart
+++ b/lib/ui/planned/planned_master_detail_screen.dart
@@ -148,7 +148,7 @@ class _PlannedMasterDetailScreenState
       return;
     }
     final repo = ref.read(transactionsRepoProvider);
-    await repo.setIncludedInPeriod(transactionId: id, value: value);
+    await repo.setPlannedIncluded(id, value);
     if (!mounted) {
       return;
     }


### PR DESCRIPTION
## Summary
- replace the home screen planned callout with an expense-only card that shows the remaining pool and an inline list of period plans with checkboxes and quick add support
- add providers and repository helpers to compute the planned pool base, remaining balance, and the sum of included planned expenses for the active period
- surface the "available for plans" header in planned sheets and ensure checkbox updates refresh the remaining balance immediately

## Testing
- not run (flutter CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d84c834e3c83268ea21271b75aea0a