### PR TITLE
Fix planned toggle migration and planned budget loading layout

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -5,7 +5,7 @@ class AppMigrations {
   AppMigrations._();
 
   /// Latest schema version supported by the application.
-  static const int latestVersion = 9;
+  static const int latestVersion = 10;
 
   static final Map<int, List<String>> _migrationScripts = {
     1: [
@@ -35,6 +35,7 @@ class AppMigrations {
           'note TEXT NULL, '
           'is_planned INTEGER NOT NULL DEFAULT 0, '
           'included_in_period INTEGER NOT NULL DEFAULT 1, '
+          "updated_at TEXT NOT NULL DEFAULT (datetime('now')), "
           'tags TEXT NULL'
           ')',
       'CREATE INDEX idx_transactions_date ON transactions(date)',
@@ -120,6 +121,9 @@ class AppMigrations {
     9: [
       'ALTER TABLE planned_master ADD COLUMN necessity_id INTEGER NULL',
       'CREATE INDEX IF NOT EXISTS idx_planned_master_necessity_id ON planned_master(necessity_id)',
+    ],
+    10: [
+      "ALTER TABLE transactions ADD COLUMN updated_at TEXT NOT NULL DEFAULT (datetime('now'))",
     ],
   };
 

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -655,15 +655,20 @@ class _PlannedOverviewState extends ConsumerState<_PlannedOverview> {
                         fontWeight: FontWeight.w600,
                       ),
                     ),
-                    loading: () => const Row(
-                      children: [
+                    loading: () => Row(
+                      children: const [
                         SizedBox(
                           width: 20,
                           height: 20,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         ),
                         SizedBox(width: 8),
-                        Text('Доступно на планы: …'),
+                        Expanded(
+                          child: Text(
+                            'Доступно на планы: …',
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
                       ],
                     ),
                     error: (_, __) => Text(


### PR DESCRIPTION
## Summary
- add the missing `updated_at` column to the transactions table definition and migrations so planned toggles can update
- prevent the planned budget loading row from overflowing by allowing the label text to shrink

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d851d80d308326ba0bc8f83b2fb4ad