### PR TITLE
Fix migrations PRAGMA query interpolation

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -171,8 +171,7 @@ class AppMigrations {
     required String columnName,
     required String alterStatement,
   }) async {
-    final columns =
-        await db.rawQuery("PRAGMA table_info(\$tableName)");
+    final columns = await db.rawQuery('PRAGMA table_info($tableName)');
     final normalizedColumnName = columnName.toLowerCase();
     final hasColumn = columns.any(
       (column) =>


### PR DESCRIPTION
## Summary
- ensure the migrations PRAGMA query interpolates the table name when checking for existing columns to avoid SQLite syntax errors

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8547e02288326a00cd4759bcbd65f