### PR TITLE
Fix missing imports for planned providers and color utils

### DIFF
--- a/lib/state/planned_providers.dart
+++ b/lib/state/planned_providers.dart
@@ -11,6 +11,7 @@ import '../utils/period_utils.dart';
 import 'app_providers.dart';
 import 'budget_providers.dart';
 import 'db_refresh.dart';
+import 'planned_master_providers.dart';
 
 enum PlannedType { income, expense, saving }
 

--- a/lib/ui/planned/planned_library_screen.dart
+++ b/lib/ui/planned/planned_library_screen.dart
@@ -10,6 +10,7 @@ import '../../state/budget_providers.dart';
 import '../../state/db_refresh.dart';
 import '../../state/planned_library_providers.dart';
 import '../../state/planned_master_providers.dart';
+import '../../utils/color_hex.dart';
 import '../../utils/formatting.dart';
 import '../../utils/plan_formatting.dart';
 import 'planned_assign_to_period_sheet.dart';


### PR DESCRIPTION
## Summary
- add the color utilities import to the planned library screen so hex color parsing resolves
- import the planned master providers in planned_providers to access the planned master repository

## Testing
- flutter analyze *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d85dd178dc8326b1e7871f35ab16b4