### PR TITLE
Ensure bootstrap seeding retries after failures

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_launcher_icons: ^0.13.1
   flutter_native_splash: ^2.4.0
+  sqflite_common_ffi: ^2.3.4+4
 
 flutter_icons:
   android: true

--- a/test/data/bootstrap/app_bootstrapper_test.dart
+++ b/test/data/bootstrap/app_bootstrapper_test.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:finance_app/data/bootstrap/app_bootstrapper.dart';
+import 'package:finance_app/data/db/app_database.dart';
+import 'package:finance_app/data/models/category.dart';
+import 'package:finance_app/data/repositories/categories_repository.dart';
+
+class _SeedingFailure implements Exception {
+  const _SeedingFailure();
+}
+
+class _FailingCategoriesRepository implements CategoriesRepository {
+  const _FailingCategoriesRepository();
+
+  @override
+  Future<void> restoreDefaults() async {
+    throw const _SeedingFailure();
+  }
+
+  @override
+  Future<void> bulkMove(List<int> ids, int? parentId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> delete(int id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<Category>> getAll() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<Category>> getByType(CategoryType type) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Category?> getById(int id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<Category>> groupsByType(CategoryType type) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<Category>> childrenOf(int groupId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<int> create(Category category) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> update(Category category) {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late Directory dbDir;
+
+  setUp(() async {
+    dbDir = await Directory.systemTemp.createTemp('finance_app_test');
+    final dbPath = p.join(dbDir.path, 'finance_app.db');
+
+    await AppDatabase.instance.close();
+    await databaseFactoryFfi.setDatabasesPath(dbDir.path);
+    await deleteDatabase(dbPath);
+  });
+
+  tearDown(() async {
+    await AppDatabase.instance.close();
+    final dbPath = p.join(dbDir.path, 'finance_app.db');
+    await deleteDatabase(dbPath);
+    if (dbDir.existsSync()) {
+      await dbDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'failed category seeding leaves seed flag unset and allows retry',
+    () async {
+      final bootstrapper = AppBootstrapper(
+        categoriesRepository: const _FailingCategoriesRepository(),
+      );
+
+      await expectLater(
+        bootstrapper.run(),
+        throwsA(isA<_SeedingFailure>()),
+      );
+
+      final db = await AppDatabase.instance.database;
+
+      final flagRows = await db.query(
+        'settings',
+        columns: ['value'],
+        where: 'key = ?',
+        whereArgs: ['_initial_seed_completed'],
+      );
+      expect(flagRows, isEmpty);
+
+      final categoriesAfterFailure = Sqflite.firstIntValue(
+            await db.rawQuery('SELECT COUNT(*) FROM categories'),
+          ) ??
+          0;
+      expect(categoriesAfterFailure, 0);
+
+      final retryBootstrapper = AppBootstrapper();
+      await retryBootstrapper.run();
+
+      final flagRowsAfterRetry = await db.query(
+        'settings',
+        columns: ['value'],
+        where: 'key = ?',
+        whereArgs: ['_initial_seed_completed'],
+      );
+      expect(flagRowsAfterRetry, isNotEmpty);
+
+      final categoriesAfterRetry = Sqflite.firstIntValue(
+            await db.rawQuery('SELECT COUNT(*) FROM categories'),
+          ) ??
+          0;
+      expect(categoriesAfterRetry, greaterThan(0));
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- defer marking the initial seed complete until after category defaults are restored
- allow injecting a categories repository and add a regression test covering failed seeding retries
- add sqflite_common_ffi as a dev dependency to support database-backed tests

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8d506788c83269670a1b0e16d9ade