### PR TITLE
Filter excluded expenses from budget totals

### DIFF
--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -571,7 +571,8 @@ class SqliteTransactionsRepository implements TransactionsRepository {
     final rows = await db.rawQuery(
       'SELECT SUM(amount_minor) AS total '
       'FROM transactions '
-      "WHERE type = 'expense' AND is_planned = 0 AND date BETWEEN ? AND ?",
+      "WHERE type = 'expense' AND is_planned = 0 AND included_in_period = 1 "
+      'AND date BETWEEN ? AND ?',
       [_formatDate(normalizedFrom), _formatDate(endInclusive)],
     );
 

--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -336,6 +336,7 @@ final halfPeriodTransactionsProvider = FutureProvider<List<TransactionRecord>>((
     start,
     endInclusive,
     isPlanned: false,
+    includedInPeriod: true,
   );
 });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_launcher_icons: ^0.13.1
   flutter_native_splash: ^2.4.0
+  sqflite_common_ffi: ^2.3.2
 
 flutter_icons:
   android: true

--- a/test/transactions_repository_test.dart
+++ b/test/transactions_repository_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_common_ffi.dart';
+
+import 'package:finance_app/data/db/app_database.dart';
+import 'package:finance_app/data/models/transaction_record.dart';
+import 'package:finance_app/data/repositories/transactions_repository.dart';
+
+void main() {
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late String databasePath;
+
+  setUpAll(() async {
+    final basePath = await getDatabasesPath();
+    databasePath = p.join(basePath, 'finance_app.db');
+  });
+
+  setUp(() async {
+    await AppDatabase.instance.close();
+    await databaseFactory.deleteDatabase(databasePath);
+  });
+
+  tearDown(() async {
+    await AppDatabase.instance.close();
+  });
+
+  test('sumUnplannedExpensesInRange ignores transactions excluded from period', () async {
+    final repository = SqliteTransactionsRepository();
+    final db = await AppDatabase.instance.database;
+
+    await db.insert('accounts', {
+      'id': 1,
+      'name': 'Cash',
+      'currency': 'RUB',
+      'start_balance_minor': 0,
+      'is_archived': 0,
+    });
+
+    await db.insert('categories', {
+      'id': 1,
+      'type': 'expense',
+      'name': 'Groceries',
+      'is_group': 0,
+      'parent_id': null,
+      'archived': 0,
+    });
+
+    final date = DateTime(2024, 1, 10);
+
+    await repository.add(
+      TransactionRecord(
+        accountId: 1,
+        categoryId: 1,
+        type: TransactionType.expense,
+        amountMinor: 5000,
+        date: date,
+        isPlanned: false,
+        includedInPeriod: true,
+      ),
+    );
+
+    await repository.add(
+      TransactionRecord(
+        accountId: 1,
+        categoryId: 1,
+        type: TransactionType.expense,
+        amountMinor: 7000,
+        date: date,
+        isPlanned: false,
+        includedInPeriod: false,
+      ),
+    );
+
+    await repository.add(
+      TransactionRecord(
+        accountId: 1,
+        categoryId: 1,
+        type: TransactionType.expense,
+        amountMinor: 9000,
+        date: date,
+        isPlanned: true,
+        includedInPeriod: true,
+      ),
+    );
+
+    final total = await repository.sumUnplannedExpensesInRange(
+      date,
+      date.add(const Duration(days: 1)),
+    );
+
+    expect(total, 5000);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure the unplanned expenses aggregate filters out transactions excluded from the period
- pass the included flag through half-period transaction queries so UI totals ignore excluded operations
- add a repository regression test covering excluded unplanned expenses using the sqflite FFI driver

## Testing
- flutter test *(fails: Flutter SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d525e47c8326bbc22ec4f210c6d1