### PR TITLE
Display assigned period for plans

### DIFF
--- a/lib/ui/planned/planned_library_screen.dart
+++ b/lib/ui/planned/planned_library_screen.dart
@@ -623,7 +623,15 @@ class PlannedMasterTile extends StatelessWidget {
     parts.add(categoryText);
     parts.add(_typeLabel(view.type));
     if (view.assignedNow) {
-      parts.add('Назначен');
+      final periodLabel = compactPeriodLabel(
+        view.assignedPeriodStart,
+        view.assignedPeriodEndExclusive,
+      );
+      if (periodLabel != null) {
+        parts.add('Назначен $periodLabel');
+      } else {
+        parts.add('Назначен');
+      }
     }
     if (view.archived) {
       parts.add('Архив');

--- a/lib/utils/plan_formatting.dart
+++ b/lib/utils/plan_formatting.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 import 'formatting.dart';
 
 String _normalizeTitle(String title) {
@@ -26,4 +28,25 @@ String oneLinePlan(String title, int? amountMinor, String? necessityLabel) {
   final amountWithCurrency = amountPart == '—' ? '— ₽' : '$amountPart ₽';
   final necessityPart = necessityLabelOrDash(necessityLabel);
   return '$normalizedTitle — $amountWithCurrency — $necessityPart';
+}
+
+String? compactPeriodLabel(
+  DateTime? start,
+  DateTime? endExclusive,
+) {
+  if (start == null || endExclusive == null) {
+    return null;
+  }
+  if (!endExclusive.isAfter(start)) {
+    return DateFormat.MMMd('ru_RU').format(start);
+  }
+  final endInclusive = endExclusive.subtract(const Duration(days: 1));
+  final sameMonth = start.year == endInclusive.year && start.month == endInclusive.month;
+  if (sameMonth) {
+    final monthLabel = DateFormat.MMM('ru_RU').format(start);
+    return '${start.day}–${endInclusive.day} $monthLabel';
+  }
+  final startLabel = DateFormat.MMMd('ru_RU').format(start);
+  final endLabel = DateFormat.MMMd('ru_RU').format(endInclusive);
+  return '$startLabel – $endLabel';
 }


### PR DESCRIPTION
## Summary
- extend planned master query to return the period bounds of assignments in the selected range
- add a compact period label helper and surface the assigned period directly in the plan library list

## Testing
- not run (flutter not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8d696c4548326a7ba4b19521e1e62