### PR TITLE
Remove sqflite_common_ffi usage for mobile builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+## Dependency maintenance
+
+After updating dependencies, run:
+
+```bash
+flutter pub get
+# При проблемах с кешем: flutter pub cache repair
+```
+
 ## Android build commands
 
 Execute the following commands locally to produce a universal debug APK with 32-bit and 64-bit support:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,6 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_launcher_icons: ^0.13.1
   flutter_native_splash: ^2.4.0
-  sqflite_common_ffi: ^2.3.4+4
 
 flutter_icons:
   android: true

--- a/test/data/bootstrap/app_bootstrapper_test.dart
+++ b/test/data/bootstrap/app_bootstrapper_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'package:finance_app/data/bootstrap/app_bootstrapper.dart';
 import 'package:finance_app/data/db/app_database.dart';
@@ -71,11 +70,6 @@ class _FailingCategoriesRepository implements CategoriesRepository {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(() {
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
-  });
-
   late Directory dbDir;
 
   setUp(() async {
@@ -83,7 +77,7 @@ void main() {
     final dbPath = p.join(dbDir.path, 'finance_app.db');
 
     await AppDatabase.instance.close();
-    await databaseFactoryFfi.setDatabasesPath(dbDir.path);
+    await databaseFactory.setDatabasesPath(dbDir.path);
     await deleteDatabase(dbPath);
   });
 

--- a/test/data/repositories/transactions_repository_test.dart
+++ b/test/data/repositories/transactions_repository_test.dart
@@ -3,18 +3,12 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'package:finance_app/data/db/app_database.dart';
 import 'package:finance_app/data/repositories/transactions_repository.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-
-  setUpAll(() {
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
-  });
 
   late Directory dbDir;
   late Database db;
@@ -50,7 +44,7 @@ void main() {
     final dbPath = p.join(dbDir.path, 'finance_app.db');
 
     await AppDatabase.instance.close();
-    await databaseFactoryFfi.setDatabasesPath(dbDir.path);
+    await databaseFactory.setDatabasesPath(dbDir.path);
     await deleteDatabase(dbPath);
 
     db = await AppDatabase.instance.database;


### PR DESCRIPTION
## Summary
- remove the sqflite_common_ffi dependency to unblock pub get authorization issues
- update database bootstrap and repository tests to rely on the default sqflite database factory
- document running flutter pub get (and cache repair) after dependency changes

## Testing
- not run (flutter is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8d8fc06348326a58f613f60183ec0