### PR TITLE
Add stub flutter_native_splash plugin for Android build

### DIFF
--- a/android/app/src/main/java/net/jonhanson/flutter_native_splash/FlutterNativeSplashPlugin.java
+++ b/android/app/src/main/java/net/jonhanson/flutter_native_splash/FlutterNativeSplashPlugin.java
@@ -1,0 +1,22 @@
+package net.jonhanson.flutter_native_splash;
+
+import androidx.annotation.NonNull;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+
+/**
+ * A minimal no-op plugin implementation to satisfy builds where flutter_native_splash
+ * is only used as a dev dependency. The actual plugin functionality is not required
+ * at runtime because the splash screen assets are generated at build time.
+ */
+public class FlutterNativeSplashPlugin implements FlutterPlugin {
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    // No-op. The flutter_native_splash package does not need runtime behavior.
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    // No-op.
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal no-op FlutterNativeSplashPlugin class in the Android sources so the generated plugin registrant can compile even when flutter_native_splash is only a dev dependency

## Testing
- not run (build fix only)


------
https://chatgpt.com/codex/tasks/task_e_68d8db795758832686d567c6c34a7ebc