### PR TITLE
Fix planned overview expansion reset after assigning master plan

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -402,7 +402,24 @@ final accountsRepositoryProvider =
 
 final isSheetOpenProvider = StateProvider<bool>((_) => false);
 
-final plannedOverviewExpandedProvider = StateProvider<bool>((_) => false);
+class PlannedOverviewExpansionController extends StateNotifier<bool> {
+  PlannedOverviewExpansionController() : super(false);
+
+  bool get isExpanded => state;
+
+  void setExpanded(bool value) => state = value;
+
+  void expand() => setExpanded(true);
+
+  void collapse() => setExpanded(false);
+
+  void toggle() => setExpanded(!state);
+}
+
+final plannedOverviewExpandedProvider =
+    StateNotifierProvider<PlannedOverviewExpansionController, bool>(
+  (_) => PlannedOverviewExpansionController(),
+);
 
 final necessityLabelsFutureProvider =
     FutureProvider<List<necessity_repo.NecessityLabel>>((ref) {

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -577,6 +577,8 @@ class _PlannedOverview extends ConsumerStatefulWidget {
 class _PlannedOverviewState extends ConsumerState<_PlannedOverview> {
   Future<void> _openQuickAdd(BuildContext context) async {
     final sheetNotifier = ref.read(isSheetOpenProvider.notifier);
+    final expansionNotifier = ref.read(plannedOverviewExpandedProvider.notifier);
+    final wasExpanded = expansionNotifier.isExpanded;
     sheetNotifier.state = true;
     try {
       final period = ref.read(selectedPeriodRefProvider);
@@ -600,6 +602,7 @@ class _PlannedOverviewState extends ConsumerState<_PlannedOverview> {
       }
     } finally {
       sheetNotifier.state = false;
+      expansionNotifier.setExpanded(wasExpanded);
     }
   }
 
@@ -693,7 +696,7 @@ class _PlannedOverviewState extends ConsumerState<_PlannedOverview> {
                   onPressed: () {
                     final notifier =
                         ref.read(plannedOverviewExpandedProvider.notifier);
-                    notifier.state = !expanded;
+                    notifier.toggle();
                   },
                 ),
               ],


### PR DESCRIPTION
## Summary
- add a dedicated controller to persist the planned overview expansion state
- restore the previous expansion value after closing the quick add / assignment sheet
- use the controller to toggle the expansion instead of writing the raw state

## Testing
- flutter analyze *(fails: Flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da933c91a88326864fe649435547d7