### PR TITLE
Adjust max daily limit to remaining period days

### DIFF
--- a/lib/ui/home/daily_limit_sheet.dart
+++ b/lib/ui/home/daily_limit_sheet.dart
@@ -141,21 +141,26 @@ class _DailyLimitSheetState extends ConsumerState<_DailyLimitSheet> {
     }
 
     final period = await ref.read(currentPeriodProvider.future);
-    final days = period.days;
-    if (days <= 0) {
-      return null;
-    }
 
-    return payout.amountMinor ~/ days;
+    return calculateMaxDailyLimitMinor(
+      payout: payout,
+      period: period,
+      today: DateTime.now(),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final payout = ref.watch(payoutForSelectedPeriodProvider).asData?.value;
     final period = ref.watch(currentPeriodProvider).asData?.value;
-    final maxDaily = payout != null && period != null && period.days > 0
-        ? payout.amountMinor ~/ period.days
-        : null;
+    final maxDaily =
+        payout != null && period != null && period.days > 0
+            ? calculateMaxDailyLimitMinor(
+                payout: payout,
+                period: period,
+                today: DateTime.now(),
+              )
+            : null;
 
     return Column(
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- add a reusable helper that derives the maximum daily limit using the remaining period days when applicable
- reuse the helper in the budget limit manager and the daily limit sheet to clamp user edits and helper text consistently

## Testing
- not run (Flutter SDK not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68da971ecd6483269ae5c9c71a5a87b0