### PR TITLE
Fix payout date clamping at period boundaries

### DIFF
--- a/lib/data/repositories/payouts_repository.dart
+++ b/lib/data/repositories/payouts_repository.dart
@@ -421,17 +421,23 @@ class SqlitePayoutsRepository implements PayoutsRepository {
     if (picked.isBefore(allowBefore)) {
       final prev = selected.prevHalf();
       final prevBounds = periodBoundsFor(prev, anchor1, anchor2);
-      final prevDate = prevBounds.endExclusive.subtract(const Duration(days: 1));
+      final prevLastDay = prevBounds.endExclusive.subtract(const Duration(days: 1));
+      final prevDate = clampDateToPeriod(
+        prevLastDay,
+        prevBounds.start,
+        prevBounds.endExclusive,
+      );
       return (prevDate, prev);
     }
 
+    final clampedCurrent = clampDateToPeriod(picked, start, endEx);
+
     if (picked.isBefore(endEx)) {
-      final date = picked.isBefore(start) ? start : picked;
-      return (date, selected);
+      return (clampedCurrent, selected);
     }
 
     if (picked.isBefore(allowAfterExclusive)) {
-      return (picked, selected);
+      return (clampedCurrent, selected);
     }
 
     var target = selected.nextHalf();
@@ -441,6 +447,12 @@ class SqlitePayoutsRepository implements PayoutsRepository {
       targetBounds = periodBoundsFor(target, anchor1, anchor2);
     }
 
-    return (picked, target);
+    final clampedTarget = clampDateToPeriod(
+      picked,
+      targetBounds.start,
+      targetBounds.endExclusive,
+    );
+
+    return (clampedTarget, target);
   }
 }

--- a/lib/utils/period_utils.dart
+++ b/lib/utils/period_utils.dart
@@ -58,6 +58,31 @@ DateTime normalizeDate(DateTime date) {
   return DateTime(date.year, date.month, date.day);
 }
 
+DateTime clampDateToPeriod(
+  DateTime value,
+  DateTime start,
+  DateTime endExclusive,
+) {
+  final normalizedStart = normalizeDate(start);
+  final normalizedEndExclusive = normalizeDate(endExclusive);
+  final normalizedValue = normalizeDate(value);
+
+  if (!normalizedEndExclusive.isAfter(normalizedStart)) {
+    return normalizedStart;
+  }
+
+  if (normalizedValue.isBefore(normalizedStart)) {
+    return normalizedStart;
+  }
+
+  if (!normalizedValue.isBefore(normalizedEndExclusive)) {
+    final lastDay = normalizedEndExclusive.subtract(const Duration(days: 1));
+    return lastDay.isBefore(normalizedStart) ? normalizedStart : lastDay;
+  }
+
+  return normalizedValue;
+}
+
 ({DateTime start, DateTime endExclusive}) periodBoundsFor(
   PeriodRef period,
   int anchor1,

--- a/test/utils/period_utils_test.dart
+++ b/test/utils/period_utils_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:finance_app/utils/period_utils.dart';
+
+void main() {
+  group('clampDateToPeriod', () {
+    final start = DateTime(2024, 5, 10);
+    final endExclusive = DateTime(2024, 5, 15);
+
+    test('keeps value within inclusive start and exclusive end', () {
+      expect(
+        clampDateToPeriod(DateTime(2024, 5, 10), start, endExclusive),
+        DateTime(2024, 5, 10),
+      );
+      expect(
+        clampDateToPeriod(DateTime(2024, 5, 14), start, endExclusive),
+        DateTime(2024, 5, 14),
+      );
+    });
+
+    test('clamps values before start to start', () {
+      expect(
+        clampDateToPeriod(DateTime(2024, 5, 9), start, endExclusive),
+        DateTime(2024, 5, 10),
+      );
+    });
+
+    test('clamps values on or after end exclusive to last allowed day', () {
+      expect(
+        clampDateToPeriod(DateTime(2024, 5, 15), start, endExclusive),
+        DateTime(2024, 5, 14),
+      );
+      expect(
+        clampDateToPeriod(DateTime(2024, 5, 16), start, endExclusive),
+        DateTime(2024, 5, 14),
+      );
+    });
+
+    test('handles degenerate periods by returning start', () {
+      final sameDayEnd = DateTime(2024, 5, 10);
+      expect(
+        clampDateToPeriod(DateTime(2024, 5, 12), start, sameDayEnd),
+        DateTime(2024, 5, 10),
+      );
+    });
+
+    test('normalizes time components', () {
+      final withTime = DateTime(2024, 5, 12, 23, 59);
+      expect(
+        clampDateToPeriod(withTime, start, endExclusive),
+        DateTime(2024, 5, 12),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to clamp dates inside a period window
- ensure payout date adjustments respect the start and endExclusive bounds
- cover the new clamp logic with unit tests for boundary cases

## Testing
- flutter test test/utils/period_utils_test.dart *(fails: flutter tool not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9c3af9dc8326ac0ab09156698329