### PR TITLE
Make registry lists compact with tooltip overflow

### DIFF
--- a/lib/ui/operations/operations_screen.dart
+++ b/lib/ui/operations/operations_screen.dart
@@ -17,6 +17,7 @@ import '../../utils/formatting.dart';
 import '../../routing/app_router.dart';
 import '../../data/repositories/transactions_repository.dart'
     show TransactionListItem;
+import '../widgets/single_line_tooltip_text.dart';
 
 final _categoriesMapProvider = FutureProvider<Map<int, Category>>((ref) async {
   ref.watch(dbTickProvider);
@@ -238,6 +239,8 @@ class _OperationsSection extends ConsumerWidget {
             return Card(
               margin: const EdgeInsets.only(bottom: 12),
               child: ListTile(
+                dense: true,
+                visualDensity: VisualDensity.compact,
                 leading: CircleAvatar(
                   backgroundColor: _colorForType(record.type).withOpacity(0.15),
                   child: Icon(
@@ -245,13 +248,17 @@ class _OperationsSection extends ConsumerWidget {
                     color: _colorForType(record.type),
                   ),
                 ),
-                title: Text(category?.name ?? 'Категория #${record.categoryId}'),
-                subtitle: Text(
-                  _subtitleForRecord(
+                title: SingleLineTooltipText(
+                  text: category?.name ?? 'Категория #${record.categoryId}',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                subtitle: SingleLineTooltipText(
+                  text: _subtitleForRecord(
                     record,
                     necessityMap,
                     reasonMap,
                   ),
+                  style: Theme.of(context).textTheme.bodyMedium,
                 ),
                 trailing: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -263,8 +270,14 @@ class _OperationsSection extends ConsumerWidget {
                         color: _colorForType(record.type),
                         fontWeight: FontWeight.bold,
                       ),
+                      softWrap: false,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    Text(_labelForType(record.type)),
+                    Text(
+                      _labelForType(record.type),
+                      softWrap: false,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ],
                 ),
                 onLongPress: () async {

--- a/lib/ui/planned/planned_library_screen.dart
+++ b/lib/ui/planned/planned_library_screen.dart
@@ -13,6 +13,7 @@ import '../../state/planned_master_providers.dart';
 import '../../utils/color_hex.dart';
 import '../../utils/formatting.dart';
 import '../../utils/plan_formatting.dart';
+import '../widgets/single_line_tooltip_text.dart';
 import 'planned_assign_to_period_sheet.dart';
 import 'planned_master_edit_sheet.dart';
 
@@ -582,19 +583,16 @@ class PlannedMasterTile extends StatelessWidget {
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       dense: true,
       visualDensity: VisualDensity.compact,
-      title: Text(
-        oneLinePlan(
+      title: SingleLineTooltipText(
+        text: oneLinePlan(
           view.title,
           view.defaultAmountMinor,
           view.necessityName,
         ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.titleMedium,
       ),
-      subtitle: Text(
-        subtitle,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+      subtitle: SingleLineTooltipText(
+        text: subtitle,
         style: theme.textTheme.bodySmall,
       ),
       trailing: PopupMenuButton<_MasterMenuAction>(

--- a/lib/ui/planned/planned_sheet.dart
+++ b/lib/ui/planned/planned_sheet.dart
@@ -10,6 +10,7 @@ import '../../state/db_refresh.dart';
 import '../../utils/formatting.dart';
 import '../../routing/app_router.dart';
 import '../../state/planned_master_providers.dart';
+import '../widgets/single_line_tooltip_text.dart';
 import 'planned_add_form.dart';
 
 Future<void> showPlannedSheet(
@@ -375,11 +376,13 @@ class _PlannedItemTile extends StatelessWidget {
                   Checkbox(
                     value: isIncluded,
                     onChanged: onToggle,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
                   ),
                   const SizedBox(width: 8),
                   Expanded(
-                    child: Text(
-                      item.title,
+                    child: SingleLineTooltipText(
+                      text: item.title,
                       style: theme.textTheme.bodyLarge,
                     ),
                   ),
@@ -387,6 +390,8 @@ class _PlannedItemTile extends StatelessWidget {
                   Text(
                     formatCurrency(item.amount),
                     style: theme.textTheme.bodyMedium,
+                    softWrap: false,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ],
               ),

--- a/lib/ui/widgets/single_line_tooltip_text.dart
+++ b/lib/ui/widgets/single_line_tooltip_text.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+class SingleLineTooltipText extends StatelessWidget {
+  const SingleLineTooltipText({
+    super.key,
+    required this.text,
+    this.style,
+    this.textAlign,
+    this.textDirection,
+    this.textScaler,
+    this.textHeightBehavior,
+    this.overflow = TextOverflow.ellipsis,
+    this.tooltipEnabled = true,
+  });
+
+  final String text;
+  final TextStyle? style;
+  final TextAlign? textAlign;
+  final TextDirection? textDirection;
+  final TextScaler? textScaler;
+  final TextHeightBehavior? textHeightBehavior;
+  final TextOverflow overflow;
+  final bool tooltipEnabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayText = text;
+    final textWidget = Text(
+      displayText,
+      maxLines: 1,
+      overflow: overflow,
+      softWrap: false,
+      style: style,
+      textAlign: textAlign,
+      textDirection: textDirection,
+      textScaler: textScaler,
+      textHeightBehavior: textHeightBehavior,
+    );
+
+    if (!tooltipEnabled || displayText.trim().isEmpty) {
+      return textWidget;
+    }
+
+    return Tooltip(
+      message: displayText,
+      waitDuration: const Duration(milliseconds: 400),
+      child: textWidget,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable single-line text widget that shows full content on long-press
- update planned and operations registries to use compact tiles with ellipsis
- keep planned item rows single-line and prevent wrapping in totals

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da9dd654788326a4f56c9e8b8ba8e0