### PR TITLE
Add option to recalculate period budget from today

### DIFF
--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -16,6 +16,10 @@ abstract class SettingsRepository {
 
   Future<void> setDailyLimitMinor(int? value);
 
+  Future<bool> getDailyLimitFromToday();
+
+  Future<void> setDailyLimitFromToday(bool value);
+
   Future<bool> getSavingPairEnabled();
 
   Future<void> setSavingPairEnabled(bool value);
@@ -32,6 +36,7 @@ class SqliteSettingsRepository implements SettingsRepository {
   static const String _anchorDay1Key = 'anchor_day_1';
   static const String _anchorDay2Key = 'anchor_day_2';
   static const String _dailyLimitKey = 'daily_limit_minor';
+  static const String _dailyLimitFromTodayKey = 'daily_limit_from_today';
   static const String _savingPairKey = 'saving_pair_enabled';
   static const String _manualBackupHistoryKey = 'manual_backup_history';
 
@@ -67,6 +72,14 @@ class SqliteSettingsRepository implements SettingsRepository {
 
   @override
   Future<void> setDailyLimitMinor(int? value) => _setNullableInt(_dailyLimitKey, value);
+
+  @override
+  Future<bool> getDailyLimitFromToday() =>
+      _getBool(_dailyLimitFromTodayKey, defaultValue: false);
+
+  @override
+  Future<void> setDailyLimitFromToday(bool value) =>
+      _setBool(_dailyLimitFromTodayKey, value);
 
   @override
   Future<void> setSavingPairEnabled(bool value) => _setBool(_savingPairKey, value);

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -47,10 +47,9 @@ class HomeScreen extends ConsumerWidget {
     );
     final today = DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
-    final isActivePeriod =
-        ref.watch(isActivePeriodProvider((normalizedToday, period)));
+    final isActivePeriod = ref.watch(isActivePeriodProvider);
     final daysLeft =
-        isActivePeriod ? ref.watch(daysToPeriodEndProvider) : null;
+        isActivePeriod ? ref.watch(daysUntilNextPayoutFromTodayProvider) : null;
     final showClosedBadge = isActivePeriod && periodClosed;
     final generalPayoutLabel =
         'Добавить выплату (по периоду: ${payoutTypeLabel(suggestedType)})';
@@ -248,7 +247,7 @@ class HomeScreen extends ConsumerWidget {
                         return;
                       }
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Лимит сохранён')),
+                        const SnackBar(content: Text('Лимит обновлён')),
                       );
                     },
                   );


### PR DESCRIPTION
## Summary
- store the daily limit recalculation preference in settings
- update budget and home providers to use remaining days when the flag is enabled
- extend the daily limit edit sheet with the "Пересчитывать от сегодня" checkbox and refresh messaging

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db86b91fa4832692d18b914c3d7e06