### PR TITLE
Keep planned expenses expansion state and allow instance deletion

### DIFF
--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -61,6 +61,8 @@ abstract class TransactionsRepository {
 
   Future<void> delete(int id);
 
+  Future<void> deletePlannedInstance(int plannedId);
+
   Future<List<TransactionRecord>> listPlanned({
     TransactionType? type,
     bool onlyIncluded = false,
@@ -210,6 +212,16 @@ class SqliteTransactionsRepository implements TransactionsRepository {
   Future<void> delete(int id) async {
     final db = await _db;
     await db.delete('transactions', where: 'id = ?', whereArgs: [id]);
+  }
+
+  @override
+  Future<void> deletePlannedInstance(int plannedId) async {
+    final db = await _db;
+    await db.delete(
+      'transactions',
+      where: 'id = ? AND is_planned = 1',
+      whereArgs: [plannedId],
+    );
   }
 
   @override

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -177,6 +177,12 @@ class _TransactionsRepositoryWithDbTick
   }
 
   @override
+  Future<void> deletePlannedInstance(int plannedId) async {
+    await _delegate.deletePlannedInstance(plannedId);
+    bumpDbTick(_ref);
+  }
+
+  @override
   Future<int> deleteInstancesByPlannedId(int plannedId) async {
     final result = await _delegate.deleteInstancesByPlannedId(plannedId);
     bumpDbTick(_ref);
@@ -543,24 +549,7 @@ final accountsRepositoryProvider =
 
 final isSheetOpenProvider = StateProvider<bool>((_) => false);
 
-class PlannedOverviewExpansionController extends StateNotifier<bool> {
-  PlannedOverviewExpansionController() : super(false);
-
-  bool get isExpanded => state;
-
-  void setExpanded(bool value) => state = value;
-
-  void expand() => setExpanded(true);
-
-  void collapse() => setExpanded(false);
-
-  void toggle() => setExpanded(!state);
-}
-
-final plannedOverviewExpandedProvider =
-    StateNotifierProvider<PlannedOverviewExpansionController, bool>(
-  (_) => PlannedOverviewExpansionController(),
-);
+final plansExpandedProvider = StateProvider<bool>((_) => false);
 
 final necessityLabelsFutureProvider =
     FutureProvider<List<necessity_repo.NecessityLabel>>((ref) {

--- a/lib/state/planned_providers.dart
+++ b/lib/state/planned_providers.dart
@@ -156,12 +156,23 @@ final plannedExpensesForPeriodProvider = FutureProvider.family
     <List<PlannedItemView>, PeriodRef>((ref, period) async {
   ref.watch(dbTickProvider);
   ref.watch(selectedPeriodRefProvider);
-  return _loadPlannedItemsForPeriod(
+  final items = await _loadPlannedItemsForPeriod(
     ref,
     PlannedType.expense,
     period,
     onlyIncluded: false,
   );
+  final sorted = [...items]
+    ..sort((a, b) {
+      final titleCompare = a.title.toLowerCase().compareTo(b.title.toLowerCase());
+      if (titleCompare != 0) {
+        return titleCompare;
+      }
+      final aId = a.record.id ?? 0;
+      final bId = b.record.id ?? 0;
+      return aId.compareTo(bId);
+    });
+  return sorted;
 });
 
 final plannedIncludedByTypeProvider = FutureProvider.family


### PR DESCRIPTION
## Summary
- persist the expansion state for home planned expenses via a dedicated provider and refactor the UI to use an ExpansionTile with keyed list items and delete affordances
- add repository support for deleting a planned instance and trigger db refresh notifications on write operations
- ensure planned expenses for the period are returned in a stable order to avoid list jitter

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbb3f046208326a36ba766210304a8