### PR TITLE
Handle payouts daily limit migration duplication

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -127,8 +127,6 @@ class AppMigrations {
     ],
     10: [],
     11: [
-      'ALTER TABLE payouts ADD COLUMN daily_limit_minor INTEGER NOT NULL DEFAULT 0',
-      'ALTER TABLE payouts ADD COLUMN daily_limit_from_today INTEGER NOT NULL DEFAULT 0',
       'CREATE INDEX IF NOT EXISTS idx_payouts_date ON payouts(date)',
     ],
   };
@@ -159,6 +157,22 @@ class AppMigrations {
             columnName: 'updated_at',
             alterStatement:
                 "ALTER TABLE transactions ADD COLUMN updated_at TEXT NOT NULL DEFAULT (datetime('now'))",
+          );
+          break;
+        case 11:
+          await _ensureColumnExists(
+            db,
+            tableName: 'payouts',
+            columnName: 'daily_limit_minor',
+            alterStatement:
+                'ALTER TABLE payouts ADD COLUMN daily_limit_minor INTEGER NOT NULL DEFAULT 0',
+          );
+          await _ensureColumnExists(
+            db,
+            tableName: 'payouts',
+            columnName: 'daily_limit_from_today',
+            alterStatement:
+                'ALTER TABLE payouts ADD COLUMN daily_limit_from_today INTEGER NOT NULL DEFAULT 0',
           );
           break;
         default:


### PR DESCRIPTION
## Summary
- avoid failing migrations when payouts table already has daily limit columns by gating ALTER statements behind schema checks
- keep index creation for payouts guarded with IF NOT EXISTS so new installs retain required schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc730f2e083269af4bf962f683eea