### PR TITLE
Handle early payouts by shifting period bounds

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -20,6 +20,19 @@ import '../data/repositories/transactions_repository.dart' as transactions_repo;
 import '../utils/period_utils.dart';
 import 'db_refresh.dart';
 
+class TelemetryService {
+  const TelemetryService();
+
+  void log(String event, {Map<String, Object?>? properties}) {
+    final payload = properties == null || properties.isEmpty ? '' : ' $properties';
+    debugPrint('[telemetry] $event$payload');
+  }
+}
+
+final telemetryProvider = Provider<TelemetryService>((_) {
+  return const TelemetryService();
+});
+
 final appDatabaseProvider = Provider<AppDatabase>((ref) => AppDatabase.instance);
 
 final appBootstrapProvider = FutureProvider<void>((ref) async {

--- a/lib/state/planned_master_providers.dart
+++ b/lib/state/planned_master_providers.dart
@@ -71,15 +71,14 @@ final availableExpenseMastersProvider = FutureProvider.family<
     List<PlannedMasterView>, (PeriodRef, ExpenseMasterFilters)>((ref, args) async {
   ref.watch(dbTickProvider);
   ref.watch(selectedPeriodRefProvider);
-  final (anchor1, anchor2) = ref.watch(anchorDaysProvider);
   final period = args.$1;
   final filters = args.$2;
-  final bounds = period.bounds(anchor1, anchor2);
+  final entry = await ref.watch(periodEntryProvider(period).future);
   final repository = ref.watch(plannedMasterRepoProvider);
   final search = filters.search.trim().isEmpty ? null : filters.search.trim();
   return repository.queryAvailableForPeriod(
-    start: bounds.start,
-    endExclusive: bounds.endExclusive,
+    start: entry.start,
+    endExclusive: entry.endExclusive,
     categoryId: filters.categoryId,
     necessityId: filters.necessityId,
     search: search,

--- a/lib/state/planned_providers.dart
+++ b/lib/state/planned_providers.dart
@@ -85,11 +85,10 @@ Future<List<PlannedItemView>> _loadPlannedItemsForPeriod(
   final transactionsRepo = ref.watch(transactionsRepoProvider);
   final categoriesRepo = ref.watch(categoriesRepositoryProvider);
   final masterRepo = ref.watch(plannedMasterRepoProvider);
-  final (anchor1, anchor2) = ref.watch(anchorDaysProvider);
-  final bounds = period.bounds(anchor1, anchor2);
+  final entry = await ref.watch(periodEntryProvider(period).future);
   final records = await transactionsRepo.listPlannedByPeriod(
-    start: bounds.start,
-    endExclusive: bounds.endExclusive,
+    start: entry.start,
+    endExclusive: entry.endExclusive,
     type: _typeToQuery(type),
     onlyIncluded: onlyIncluded ? true : null,
   );
@@ -233,13 +232,12 @@ final sumIncludedPlannedExpensesProvider =
     FutureProvider.family<int, PeriodRef>((ref, period) async {
   ref.watch(dbTickProvider);
   ref.watch(selectedPeriodRefProvider);
-  final (anchor1, anchor2) = ref.watch(anchorDaysProvider);
-  final bounds = period.bounds(anchor1, anchor2);
+  final entry = await ref.watch(periodEntryProvider(period).future);
   final repository = ref.watch(transactionsRepoProvider);
   return repository.sumIncludedPlannedExpenses(
     period: period,
-    start: bounds.start,
-    endExclusive: bounds.endExclusive,
+    start: entry.start,
+    endExclusive: entry.endExclusive,
   );
 });
 

--- a/lib/ui/planned/expense_plan_sheets.dart
+++ b/lib/ui/planned/expense_plan_sheets.dart
@@ -937,12 +937,11 @@ class _SelectFromMasterSheetState
     }
     try {
       final transactionsRepo = ref.read(transactionsRepoProvider);
-      final (anchor1, anchor2) = ref.read(anchorDaysProvider);
-      final bounds = widget.period.bounds(anchor1, anchor2);
+      final entry = await ref.read(periodEntryProvider(widget.period).future);
       await transactionsRepo.assignMasterToPeriod(
         masterId: master.id,
-        start: bounds.start,
-        endExclusive: bounds.endExclusive,
+        start: entry.start,
+        endExclusive: entry.endExclusive,
         categoryId: categoryId,
         amountMinor: amountMinor,
         included: result.include,

--- a/lib/ui/planned/planned_master_detail_screen.dart
+++ b/lib/ui/planned/planned_master_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import '../../data/models/transaction_record.dart';
 import '../../data/repositories/planned_master_repository.dart';
@@ -8,9 +9,7 @@ import '../../state/db_refresh.dart';
 import '../../state/planned_master_providers.dart';
 import '../../state/app_providers.dart';
 import '../../state/planned_providers.dart';
-import '../../utils/date_ru.dart';
 import '../../utils/formatting.dart';
-import '../../utils/period_utils.dart';
 import 'planned_assign_to_period_sheet.dart';
 import 'planned_master_edit_sheet.dart';
 
@@ -443,7 +442,8 @@ enum _DeleteMasterChoice {
 enum _InstanceMenuAction { deleteInstance, deleteMaster }
 
 String periodBadge(DateTime start, DateTime endEx) {
-  final month = ruMonthShort(start.month);
-  final to = endEx.subtract(const Duration(days: 1)).day;
-  return '$month ${start.day}–$to';
+  final startLabel = DateFormat('d MMM', 'ru').format(start);
+  final endLabel =
+      DateFormat('d MMM', 'ru').format(endEx.subtract(const Duration(days: 1)));
+  return '$startLabel – $endLabel';
 }

--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import '../../data/models/category.dart';
 import '../../data/models/transaction_record.dart';
@@ -13,7 +14,6 @@ import '../../state/planned_master_providers.dart';
 import '../../state/planned_providers.dart';
 import '../../utils/app_exceptions.dart';
 import '../../utils/color_hex.dart';
-import '../../utils/date_ru.dart';
 import '../../utils/formatting.dart';
 import '../../utils/period_utils.dart';
 import '../settings/necessity_settings_screen.dart';
@@ -768,9 +768,10 @@ class _PlannedMasterEditFormState
   }
 
   String _formatPeriodLabel(DateTime start, DateTime endExclusive) {
-    final month = ruMonthShort(start.month);
-    final endInclusive = endExclusive.subtract(const Duration(days: 1));
-    return '$month ${start.day}–${endInclusive.day}';
+    final startLabel = DateFormat('d MMM', 'ru').format(start);
+    final endLabel =
+        DateFormat('d MMM', 'ru').format(endExclusive.subtract(const Duration(days: 1)));
+    return '$startLabel – $endLabel';
   }
 
   void _showSnack(String message, {Color? background, Color? textColor}) {

--- a/lib/utils/period_utils.dart
+++ b/lib/utils/period_utils.dart
@@ -54,6 +54,14 @@ class PeriodRef {
   }
 }
 
+extension PeriodRefIdentifier on PeriodRef {
+  String get id {
+    final monthLabel = month.toString().padLeft(2, '0');
+    final halfLabel = half == HalfPeriod.first ? 'H1' : 'H2';
+    return '${year.toString().padLeft(4, '0')}-$monthLabel-$halfLabel';
+  }
+}
+
 DateTime normalizeDate(DateTime date) {
   return DateTime(date.year, date.month, date.day);
 }


### PR DESCRIPTION
## Summary
- preserve earlier period start dates in the periods repository and expose them through new providers so active views use the adjusted bounds immediately
- update the payout sheet to prompt for early payouts, shift the stored start date without creating a new period, emit telemetry, and refresh budget metrics in place
- switch planned period labels to intl-based formatting to avoid the private _ruMonthShort helper crash

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb166755c8326b7f35229cdfef14a