### PR TITLE
Fix missing import for period utilities

### DIFF
--- a/lib/ui/planned/planned_master_detail_screen.dart
+++ b/lib/ui/planned/planned_master_detail_screen.dart
@@ -10,6 +10,7 @@ import '../../state/planned_master_providers.dart';
 import '../../state/app_providers.dart';
 import '../../state/planned_providers.dart';
 import '../../utils/formatting.dart';
+import '../../utils/period_utils.dart';
 import 'planned_assign_to_period_sheet.dart';
 import 'planned_master_edit_sheet.dart';
 


### PR DESCRIPTION
## Summary
- add the period utilities import to the planned master detail screen so periodRefForDate is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfb9ddc8808326afff026b01d66517