### PR TITLE
Ensure payout operations display in current period

### DIFF
--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -27,6 +27,8 @@ abstract class TransactionsRepository {
 
   Future<List<TransactionRecord>> getAll();
 
+  Future<TransactionRecord?> findByPayoutId(int payoutId);
+
   Future<List<TransactionRecord>> getByPeriod(
     DateTime from,
     DateTime to, {
@@ -147,6 +149,21 @@ class SqliteTransactionsRepository implements TransactionsRepository {
   final AppDatabase _database;
 
   Future<Database> get _db async => _database.database;
+
+  @override
+  Future<TransactionRecord?> findByPayoutId(int payoutId) async {
+    final db = await _db;
+    final rows = await db.query(
+      'transactions',
+      where: 'payout_id = ?',
+      whereArgs: [payoutId],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return TransactionRecord.fromMap(rows.first);
+  }
 
   @override
   Future<int> add(

--- a/lib/state/operations_filters.dart
+++ b/lib/state/operations_filters.dart
@@ -2,7 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/models/transaction_record.dart';
 import '../data/repositories/transactions_repository.dart';
+import '../utils/period_utils.dart';
 import 'app_providers.dart';
+import 'budget_providers.dart';
 import 'db_refresh.dart';
 
 enum OpTypeFilter { all, expense, income, saving }
@@ -40,12 +42,47 @@ final periodOperationsProvider =
       endInclusive = bounds.start;
     }
 
-    return repository.getOperationItemsByPeriod(
+    final transactions = await repository.getOperationItemsByPeriod(
       bounds.start,
       endInclusive,
       type: type,
       isPlanned: false,
       aggregateSavingPairs: savingPairEnabled,
     );
+
+    final result = [...transactions];
+
+    if (filter == OpTypeFilter.all || filter == OpTypeFilter.income) {
+      final payout = await ref.watch(payoutForSelectedPeriodProvider.future);
+      final payoutId = payout?.id;
+      if (payoutId != null) {
+        final payoutRecord = await repository.findByPayoutId(payoutId);
+        if (payoutRecord != null) {
+          final normalizedStart = normalizeDate(bounds.start);
+          final normalizedEndExclusive = normalizeDate(bounds.endExclusive);
+          final payoutDate = normalizeDate(payoutRecord.date);
+          final withinBounds = !payoutDate.isBefore(normalizedStart) &&
+              payoutDate.isBefore(normalizedEndExclusive);
+          final alreadyIncluded = result.any(
+            (item) => item.record.id != null &&
+                item.record.id == payoutRecord.id,
+          );
+          if (!alreadyIncluded && !withinBounds) {
+            result.add(TransactionListItem(record: payoutRecord));
+            result.sort((a, b) {
+              final cmp = b.record.date.compareTo(a.record.date);
+              if (cmp != 0) {
+                return cmp;
+              }
+              final aId = a.record.id ?? 0;
+              final bId = b.record.id ?? 0;
+              return bId.compareTo(aId);
+            });
+          }
+        }
+      }
+    }
+
+    return result;
   },
 );


### PR DESCRIPTION
## Summary
- add a repository helper to fetch transactions by payout identifier
- ensure the current period operations list appends the payout transaction even when its date falls outside the active period

## Testing
- `flutter test` *(fails: Flutter CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e013baa9748326ae530bb7efd8a1cd