### PR TITLE
Implement payout lookup delegation

### DIFF
--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -145,6 +145,13 @@ class _TransactionsRepositoryWithDbTick
   final transactions_repo.TransactionsRepository _delegate;
 
   @override
+  Future<transaction_models.TransactionRecord?> findByPayoutId(
+    int payoutId,
+  ) {
+    return _delegate.findByPayoutId(payoutId);
+  }
+
+  @override
   Future<int> add(
     transaction_models.TransactionRecord record, {
     bool asSavingPair = false,


### PR DESCRIPTION
## Summary
- delegate `findByPayoutId` in the database tick aware transactions repository wrapper to the underlying repository implementation

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e016a119088326bac33cff18c1d677