### PR TITLE
Handle existing start anchor column in period migrations

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -131,9 +131,7 @@ class AppMigrations {
       'CREATE INDEX IF NOT EXISTS idx_payouts_date ON payouts(date)',
     ],
     12: [],
-    13: [
-      'ALTER TABLE periods ADD COLUMN start_anchor_payout_id INTEGER NULL',
-    ],
+    13: [],
   };
 
   /// Applies migrations from [oldVersion] (exclusive) up to [newVersion] (inclusive).
@@ -202,6 +200,15 @@ class AppMigrations {
             'CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_plan_instance_account '
             'ON transactions(plan_instance_id, account_id) '
             'WHERE plan_instance_id IS NOT NULL',
+          );
+          break;
+        case 13:
+          await _ensureColumnExists(
+            db,
+            tableName: 'periods',
+            columnName: 'start_anchor_payout_id',
+            alterStatement:
+                'ALTER TABLE periods ADD COLUMN start_anchor_payout_id INTEGER NULL',
           );
           break;
         default:


### PR DESCRIPTION
## Summary
- prevent migration 13 from unconditionally adding start_anchor_payout_id when the column already exists
- use the existing helper to add the column only if it is missing

## Testing
- flutter test *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0192d44848326bec7591ca3be6a0d