### PR TITLE
Fix payout lookup for shifted period bounds

### DIFF
--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -191,7 +191,9 @@ final periodBoundsForProvider =
 final payoutForPeriodProvider =
     FutureProvider.family<Payout?, PeriodRef>((ref, period) async {
   ref.watch(dbTickProvider);
-  final (start, endEx) = ref.watch(periodBoundsForProvider(period));
+  final entry = await ref.watch(periodEntryProvider(period).future);
+  final start = entry.start;
+  final endEx = entry.endExclusive;
   final repo = ref.watch(payoutsRepoProvider);
   try {
     return await repo.findInRange(start, endEx);


### PR DESCRIPTION
## Summary
- ensure payout lookup relies on the persisted period entry bounds so early payouts remain associated with the current period

## Testing
- Not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e01b5c68f883268dc2aad52a32ee79