### PR TITLE
Improve database concurrency and startup seeding

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -5,7 +5,7 @@ class AppMigrations {
   AppMigrations._();
 
   /// Latest schema version supported by the application.
-  static const int latestVersion = 13;
+  static const int latestVersion = 14;
 
   static final Map<int, List<String>> _migrationScripts = {
     1: [
@@ -132,6 +132,12 @@ class AppMigrations {
     ],
     12: [],
     13: [],
+    14: [
+      'CREATE INDEX IF NOT EXISTS idx_transactions_is_planned_date '
+          'ON transactions(is_planned, date)',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_type_planned_included_date '
+          'ON transactions(type, is_planned, included_in_period, date)',
+    ],
   };
 
   /// Applies migrations from [oldVersion] (exclusive) up to [newVersion] (inclusive).


### PR DESCRIPTION
## Summary
- prevent concurrent SQLite opens by synchronizing AppDatabase initialization
- speed up default category seeding by caching existing rows during restore
- add composite indexes to accelerate planned transaction queries

## Testing
- flutter test *(fails: Flutter SDK is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0218de5a883269f2c86d4c96f644f