### PR TITLE
Ensure planned master writes honor synchronized transactions

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -5,7 +5,7 @@ class AppMigrations {
   AppMigrations._();
 
   /// Latest schema version supported by the application.
-  static const int latestVersion = 14;
+  static const int latestVersion = 15;
 
   static final Map<int, List<String>> _migrationScripts = {
     1: [
@@ -137,6 +137,20 @@ class AppMigrations {
           'ON transactions(is_planned, date)',
       'CREATE INDEX IF NOT EXISTS idx_transactions_type_planned_included_date '
           'ON transactions(type, is_planned, included_in_period, date)',
+    ],
+    15: [
+      'CREATE INDEX IF NOT EXISTS idx_transactions_included_date '
+          'ON transactions(included_in_period, date)',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_category_date '
+          'ON transactions(category_id, date)',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_planned_date '
+          'ON transactions(planned_id, date)',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_payout_date '
+          'ON transactions(payout_id, date)',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_plan_source '
+          'ON transactions(plan_instance_id, source)',
+      'CREATE INDEX IF NOT EXISTS idx_payouts_account_date ON payouts(account_id, date)',
+      'CREATE INDEX IF NOT EXISTS idx_periods_closed_start ON periods(closed, start)',
     ],
   };
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,12 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:sqflite/sqflite.dart';
 
 import 'app.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   Intl.defaultLocale = 'ru_RU';
   await initializeDateFormatting('ru_RU');
+
+  assert(() {
+    Sqflite.setDebugModeOn(true);
+    return true;
+  }());
 
   runApp(const ProviderScope(child: FinanceApp()));
 }

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sqflite/sqflite.dart';
 
 import '../data/bootstrap/app_bootstrapper.dart';
 import '../data/db/app_database.dart';
@@ -156,13 +157,17 @@ class _TransactionsRepositoryWithDbTick
     transaction_models.TransactionRecord record, {
     bool asSavingPair = false,
     bool? includedInPeriod,
+    DatabaseExecutor? executor,
   }) async {
     final result = await _delegate.add(
       record,
       asSavingPair: asSavingPair,
       includedInPeriod: includedInPeriod,
+      executor: executor,
     );
-    bumpDbTick(_ref);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
     return result;
   }
 
@@ -176,6 +181,7 @@ class _TransactionsRepositoryWithDbTick
     required bool included,
     int? necessityId,
     String? note,
+    DatabaseExecutor? executor,
   }) async {
     await _delegate.assignMasterToPeriod(
       masterId: masterId,
@@ -186,26 +192,40 @@ class _TransactionsRepositoryWithDbTick
       included: included,
       necessityId: necessityId,
       note: note,
+      executor: executor,
     );
-    bumpDbTick(_ref);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
-  Future<void> delete(int id) async {
-    await _delegate.delete(id);
-    bumpDbTick(_ref);
+  Future<void> delete(int id, {DatabaseExecutor? executor}) async {
+    await _delegate.delete(id, executor: executor);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
-  Future<void> deletePlannedInstance(int plannedId) async {
-    await _delegate.deletePlannedInstance(plannedId);
-    bumpDbTick(_ref);
+  Future<void> deletePlannedInstance(int plannedId,
+      {DatabaseExecutor? executor}) async {
+    await _delegate.deletePlannedInstance(plannedId, executor: executor);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
-  Future<int> deleteInstancesByPlannedId(int plannedId) async {
-    final result = await _delegate.deleteInstancesByPlannedId(plannedId);
-    bumpDbTick(_ref);
+  Future<int> deleteInstancesByPlannedId(int plannedId,
+      {DatabaseExecutor? executor}) async {
+    final result = await _delegate.deleteInstancesByPlannedId(
+      plannedId,
+      executor: executor,
+    );
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
     return result;
   }
 
@@ -303,6 +323,7 @@ class _TransactionsRepositoryWithDbTick
     String? necessityLabel,
     bool includedInPeriod = false,
     int criticality = 0,
+    DatabaseExecutor? executor,
   }) async {
     final result = await _delegate.createPlannedInstance(
       plannedId: plannedId,
@@ -316,8 +337,11 @@ class _TransactionsRepositoryWithDbTick
       necessityLabel: necessityLabel,
       includedInPeriod: includedInPeriod,
       criticality: criticality,
+      executor: executor,
     );
-    bumpDbTick(_ref);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
     return result;
   }
 
@@ -338,24 +362,42 @@ class _TransactionsRepositoryWithDbTick
   Future<void> setIncludedInPeriod({
     required int transactionId,
     required bool value,
+    DatabaseExecutor? executor,
   }) async {
     await _delegate.setIncludedInPeriod(
       transactionId: transactionId,
       value: value,
+      executor: executor,
     );
-    bumpDbTick(_ref);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
-  Future<void> setPlannedCompletion(int id, bool isCompleted) async {
-    await _delegate.setPlannedCompletion(id, isCompleted);
-    bumpDbTick(_ref);
+  Future<void> setPlannedCompletion(int id, bool isCompleted,
+      {DatabaseExecutor? executor}) async {
+    await _delegate.setPlannedCompletion(
+      id,
+      isCompleted,
+      executor: executor,
+    );
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
-  Future<void> setPlannedIncluded(int plannedId, bool included) async {
-    await _delegate.setPlannedIncluded(plannedId, included);
-    bumpDbTick(_ref);
+  Future<void> setPlannedIncluded(int plannedId, bool included,
+      {DatabaseExecutor? executor}) async {
+    await _delegate.setPlannedIncluded(
+      plannedId,
+      included,
+      executor: executor,
+    );
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
@@ -401,12 +443,16 @@ class _TransactionsRepositoryWithDbTick
   Future<void> update(
     transaction_models.TransactionRecord record, {
     bool? includedInPeriod,
+    DatabaseExecutor? executor,
   }) async {
     await _delegate.update(
       record,
       includedInPeriod: includedInPeriod,
+      executor: executor,
     );
-    bumpDbTick(_ref);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 }
 
@@ -422,19 +468,23 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
     DateTime date,
     int amountMinor, {
     int? accountId,
+    DatabaseExecutor? executor,
   }) {
     return _delegate.add(
       type,
       date,
       amountMinor,
       accountId: accountId,
+      executor: executor,
     );
   }
 
   @override
-  Future<void> delete(int id) async {
-    await _delegate.delete(id);
-    bumpDbTick(_ref);
+  Future<void> delete(int id, {DatabaseExecutor? executor}) async {
+    await _delegate.delete(id, executor: executor);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
@@ -468,13 +518,17 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
     required int payoutId,
     required int dailyLimitMinor,
     required bool fromToday,
+    DatabaseExecutor? executor,
   }) async {
     await _delegate.setDailyLimit(
       payoutId: payoutId,
       dailyLimitMinor: dailyLimitMinor,
       fromToday: fromToday,
+      executor: executor,
     );
-    bumpDbTick(_ref);
+    if (executor == null) {
+      bumpDbTick(_ref);
+    }
   }
 
   @override
@@ -489,6 +543,7 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
     required DateTime date,
     required int amountMinor,
     int? accountId,
+    DatabaseExecutor? executor,
   }) {
     return _delegate.update(
       id: id,
@@ -496,6 +551,7 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
       date: date,
       amountMinor: amountMinor,
       accountId: accountId,
+      executor: executor,
     );
   }
 
@@ -509,6 +565,7 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
     required int amountMinor,
     int? accountId,
     bool shiftPeriodStart = false,
+    DatabaseExecutor? executor,
   }) {
     return _delegate.upsertWithClampToSelectedPeriod(
       existing: existing,
@@ -518,6 +575,7 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
       amountMinor: amountMinor,
       accountId: accountId,
       shiftPeriodStart: shiftPeriodStart,
+      executor: executor,
     );
   }
 }

--- a/lib/state/planned_master_providers.dart
+++ b/lib/state/planned_master_providers.dart
@@ -250,8 +250,7 @@ class PlannedFacade {
     final necessityLabel =
         necessityId == null ? null : await _loadNecessityLabel(necessityId);
 
-    final db = await _database.database;
-    await db.transaction((txn) async {
+    await _database.runInWriteTransaction((txn) async {
       PlannedMaster? master;
       if (reuseExisting) {
         master = await _masterRepository.findByTitleAndType(
@@ -286,7 +285,7 @@ class PlannedFacade {
         note: sanitizedNote,
         executor: txn,
       );
-    });
+    }, debugContext: 'plannedMaster.createAndAssign');
   }
 
   Future<(int, int)> _resolveAnchors() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_riverpod: ^2.5.1
   go_router: ^14.2.0
   sqflite: ^2.3.3+1
+  synchronized: ^3.1.0
   path: ^1.9.0
   path_provider: ^2.1.4
   file_picker: ^8.1.2


### PR DESCRIPTION
## Summary
- add a shared `_runWrite` helper in the planned master repository so write flows reuse the global lock and transaction runner
- update planned master repository interfaces to accept optional `DatabaseExecutor` instances and refactor create/update/delete paths to use the shared helper
- allow callers to participate in existing transactions when mutating planned master data

## Testing
- not run (dart tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e03f37e6208326afb012faea9cea81