### PR TITLE
Use rawQuery for SQLite pragmas during configuration

### DIFF
--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -70,8 +70,8 @@ class AppDatabase {
       path,
       version: AppMigrations.latestVersion,
       onConfigure: (db) async {
-        await db.execute('PRAGMA journal_mode = WAL;');
-        await db.execute('PRAGMA busy_timeout = 10000;');
+        await db.rawQuery('PRAGMA journal_mode = WAL;');
+        await db.rawQuery('PRAGMA busy_timeout = 10000;');
         await db.execute('PRAGMA foreign_keys = ON;');
       },
       onCreate: (db, version) async {


### PR DESCRIPTION
## Summary
- switch the journal mode and busy timeout pragmas to use rawQuery during database configuration
- keep the foreign key pragma executed normally while avoiding the SQLite exception on startup

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0d8207404832694f5dc6385660f33