### PR TITLE
Fix loading operations for previous periods

### DIFF
--- a/lib/data/repositories/periods_repository.dart
+++ b/lib/data/repositories/periods_repository.dart
@@ -291,7 +291,7 @@ class SqlitePeriodsRepository implements PeriodsRepository {
     if (rows.isEmpty) {
       return null;
     }
-    return rows.first;
+    return Map<String, Object?>.from(rows.first);
   }
 
   Future<Map<String, Object?>?> _findById(DatabaseExecutor executor, int id) async {
@@ -304,7 +304,7 @@ class SqlitePeriodsRepository implements PeriodsRepository {
     if (rows.isEmpty) {
       return null;
     }
-    return rows.first;
+    return Map<String, Object?>.from(rows.first);
   }
 
   PeriodEntry _mapEntry(Map<String, Object?> row) {


### PR DESCRIPTION
## Summary
- ensure period lookup rows from SQLite are mutable before adjusting their values
- prevents read-only map mutations when opening historical periods

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a60a6308326b2c383decb9a52b8