### PR TITLE
Add reopen period action to home screen

### DIFF
--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -125,6 +125,53 @@ class HomeScreen extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              if (periodClosed) ...[
+                MaterialBanner(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  content: const Text(
+                    'Период закрыт. Откройте его, чтобы продолжить редактировать данные.',
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () async {
+                        final read = ref.read;
+                        final periodRef = read(selectedPeriodRefProvider);
+                        final periodLabel = read(periodLabelProvider);
+                        try {
+                          await read(periodsRepoProvider).reopen(periodRef);
+                          ref.invalidate(periodStatusProvider(periodRef));
+                          ref.invalidate(periodToCloseProvider);
+                          bumpDbTick(ref);
+                          if (!context.mounted) {
+                            return;
+                          }
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                'Период $periodLabel открыт для редактирования',
+                              ),
+                            ),
+                          );
+                        } catch (error) {
+                          if (!context.mounted) {
+                            return;
+                          }
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                'Не удалось открыть период: $error',
+                              ),
+                            ),
+                          );
+                        }
+                      },
+                      child: const Text('Открыть период'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+              ],
               if (closablePeriod != null) ...[
                 MaterialBanner(
                   padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),


### PR DESCRIPTION
## Summary
- add a repository API for reopening a specific period
- show a banner on the home screen that lets the user reopen a closed period and refresh dependent state

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a6d57188326bb2d89ee321bb63b