### PR TITLE
Fix payout type resolution during save

### DIFF
--- a/lib/ui/payouts/payout_edit_sheet.dart
+++ b/lib/ui/payouts/payout_edit_sheet.dart
@@ -428,8 +428,9 @@ class _PayoutEditSheetState extends ConsumerState<_PayoutEditSheet> {
     try {
       final payoutsRepo = ref.read(payoutsRepoProvider);
       final initial = widget.initial;
-      final type = _resolveType();
       final selected = selectedPeriod;
+      final allowedType = allowedPayoutTypeForHalf(selected.half);
+      final type = _resolveType(allowedType);
       final result = await payoutsRepo.upsertWithClampToSelectedPeriod(
         existing: initial,
         selectedPeriod: selected,


### PR DESCRIPTION
## Summary
- ensure payout edit sheet resolves the allowed type before saving
- reuse the same allowed type logic from build when calling `_resolveType`

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3800374b483269775fad65693de3f