### PR TITLE
Track payout origin period and scope payout income

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -5,7 +5,7 @@ class AppMigrations {
   AppMigrations._();
 
   /// Latest schema version supported by the application.
-  static const int latestVersion = 15;
+  static const int latestVersion = 16;
 
   static final Map<int, List<String>> _migrationScripts = {
     1: [
@@ -151,6 +151,12 @@ class AppMigrations {
           'ON transactions(plan_instance_id, source)',
       'CREATE INDEX IF NOT EXISTS idx_payouts_account_date ON payouts(account_id, date)',
       'CREATE INDEX IF NOT EXISTS idx_periods_closed_start ON periods(closed, start)',
+    ],
+    16: [
+      'ALTER TABLE payouts ADD COLUMN assigned_period_id TEXT NULL',
+      'ALTER TABLE transactions ADD COLUMN payout_period_id TEXT NULL',
+      'CREATE INDEX IF NOT EXISTS idx_payouts_assigned_period ON payouts(assigned_period_id)',
+      'CREATE INDEX IF NOT EXISTS idx_transactions_payout_period ON transactions(payout_period_id)',
     ],
   };
 

--- a/lib/data/models/payout.dart
+++ b/lib/data/models/payout.dart
@@ -9,6 +9,7 @@ class Payout {
     this.accountId,
     this.dailyLimitMinor = 0,
     this.dailyLimitFromToday = false,
+    this.assignedPeriodId,
   });
 
   final int? id;
@@ -18,6 +19,7 @@ class Payout {
   final int? accountId;
   final int dailyLimitMinor;
   final bool dailyLimitFromToday;
+  final String? assignedPeriodId;
 
   Payout copyWith({
     int? id,
@@ -27,6 +29,7 @@ class Payout {
     int? accountId,
     int? dailyLimitMinor,
     bool? dailyLimitFromToday,
+    Object? assignedPeriodId = _unset,
   }) {
     return Payout(
       id: id ?? this.id,
@@ -37,8 +40,13 @@ class Payout {
       dailyLimitMinor: dailyLimitMinor ?? this.dailyLimitMinor,
       dailyLimitFromToday:
           dailyLimitFromToday ?? this.dailyLimitFromToday,
+      assignedPeriodId: assignedPeriodId == _unset
+          ? this.assignedPeriodId
+          : assignedPeriodId as String?,
     );
   }
+
+  static const Object _unset = Object();
 
   factory Payout.fromMap(Map<String, Object?> map) {
     return Payout(
@@ -50,6 +58,7 @@ class Payout {
       dailyLimitMinor: map['daily_limit_minor'] as int? ?? 0,
       dailyLimitFromToday:
           (map['daily_limit_from_today'] as int? ?? 0) == 1,
+      assignedPeriodId: map['assigned_period_id'] as String?,
     );
   }
 
@@ -62,6 +71,7 @@ class Payout {
       'account_id': accountId,
       'daily_limit_minor': dailyLimitMinor,
       'daily_limit_from_today': dailyLimitFromToday ? 1 : 0,
+      'assigned_period_id': assignedPeriodId,
     };
   }
 

--- a/lib/data/models/transaction_record.dart
+++ b/lib/data/models/transaction_record.dart
@@ -23,6 +23,7 @@ class TransactionRecord {
     this.reasonId,
     this.reasonLabel,
     this.source,
+    this.payoutPeriodId,
   });
 
   final int? id;
@@ -34,7 +35,7 @@ class TransactionRecord {
   final String? time;
   final String? note;
   final int? plannedId;
-   final int? planInstanceId;
+  final int? planInstanceId;
   final bool isPlanned;
   final bool includedInPeriod;
   final List<String> tags;
@@ -44,6 +45,7 @@ class TransactionRecord {
   final int? reasonId;
   final String? reasonLabel;
   final String? source;
+  final String? payoutPeriodId;
 
   TransactionRecord copyWith({
     int? id,
@@ -65,6 +67,7 @@ class TransactionRecord {
     Object? reasonId = _unset,
     Object? reasonLabel = _unset,
     Object? source = _unset,
+    Object? payoutPeriodId = _unset,
   }) {
     return TransactionRecord(
       id: id ?? this.id,
@@ -96,6 +99,9 @@ class TransactionRecord {
           ? this.reasonLabel
           : reasonLabel as String?,
       source: source == _unset ? this.source : source as String?,
+      payoutPeriodId: payoutPeriodId == _unset
+          ? this.payoutPeriodId
+          : payoutPeriodId as String?,
     );
   }
 
@@ -120,6 +126,7 @@ class TransactionRecord {
       reasonId: map['reason_id'] as int?,
       reasonLabel: map['reason_label'] as String?,
       source: map['source'] as String?,
+      payoutPeriodId: map['payout_period_id'] as String?,
     );
   }
 
@@ -144,6 +151,7 @@ class TransactionRecord {
       'reason_id': reasonId,
       'reason_label': reasonLabel,
       'source': source,
+      'payout_period_id': payoutPeriodId,
     };
   }
 

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -250,6 +250,7 @@ class _TransactionsRepositoryWithDbTick
     transaction_models.TransactionType? type,
     bool? isPlanned,
     bool? includedInPeriod,
+    String? periodId,
   }) {
     return _delegate.getByPeriod(
       from,
@@ -259,6 +260,7 @@ class _TransactionsRepositoryWithDbTick
       type: type,
       isPlanned: isPlanned,
       includedInPeriod: includedInPeriod,
+      periodId: periodId,
     );
   }
 
@@ -273,6 +275,7 @@ class _TransactionsRepositoryWithDbTick
     bool? isPlanned,
     bool? includedInPeriod,
     bool aggregateSavingPairs = false,
+    String? periodId,
   }) {
     return _delegate.getOperationItemsByPeriod(
       from,
@@ -283,6 +286,7 @@ class _TransactionsRepositoryWithDbTick
       isPlanned: isPlanned,
       includedInPeriod: includedInPeriod,
       aggregateSavingPairs: aggregateSavingPairs,
+      periodId: periodId,
     );
   }
 
@@ -492,9 +496,14 @@ class _PayoutsRepositoryWithDbTick implements payouts_repo.PayoutsRepository {
   @override
   Future<payout_models.Payout?> findInRange(
     DateTime start,
-    DateTime endExclusive,
-  ) {
-    return _delegate.findInRange(start, endExclusive);
+    DateTime endExclusive, {
+    String? assignedPeriodId,
+  }) {
+    return _delegate.findInRange(
+      start,
+      endExclusive,
+      assignedPeriodId: assignedPeriodId,
+    );
   }
 
   @override

--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -201,7 +201,11 @@ final payoutForPeriodProvider =
   final endEx = entry.endExclusive;
   final repo = ref.watch(payoutsRepoProvider);
   try {
-    return await repo.findInRange(start, endEx);
+    return await repo.findInRange(
+      start,
+      endEx,
+      assignedPeriodId: period.id,
+    );
   } catch (error, stackTrace) {
     if (_isMissingRepoMethod(error)) {
       debugPrint(
@@ -584,6 +588,7 @@ final plannedPoolBaseProvider = FutureProvider<int>((ref) async {
 final halfPeriodTransactionsProvider = FutureProvider<List<TransactionRecord>>((ref) async {
   ref.watch(dbTickProvider);
   final (start, endExclusive) = ref.watch(periodBoundsProvider);
+  final period = ref.watch(selectedPeriodRefProvider);
   final repo = ref.watch(transactionsRepoProvider);
   var endInclusive = endExclusive.subtract(const Duration(days: 1));
   if (endInclusive.isBefore(start)) {
@@ -594,6 +599,7 @@ final halfPeriodTransactionsProvider = FutureProvider<List<TransactionRecord>>((
     endInclusive,
     isPlanned: false,
     includedInPeriod: true,
+    periodId: period.id,
   );
 });
 

--- a/lib/ui/payouts/payout_edit_sheet.dart
+++ b/lib/ui/payouts/payout_edit_sheet.dart
@@ -37,7 +37,12 @@ Future<void> showPayoutForSelectedPeriod(
   final container = ProviderScope.containerOf(context, listen: false);
   final read = container.read;
   final (start, endEx) = read(periodBoundsProvider);
-  final existing = await read(payoutsRepoProvider).findInRange(start, endEx);
+  final period = read(selectedPeriodRefProvider);
+  final existing = await read(payoutsRepoProvider).findInRange(
+    start,
+    endEx,
+    assignedPeriodId: period.id,
+  );
   await showPayoutEditSheet(
     context,
     forcedType: forcedType,


### PR DESCRIPTION
## Summary
- add an assigned_period_id column to payouts/transactions and expose it on the Payout model
- ensure payout CRUD logic captures the selected period and syncs income transactions with that period id
- filter payout lookups and transaction queries so payout income only appears in its assigned period

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e39fba7504832684658f5eeac87eee