### PR TITLE
Fix duration positivity check for period close timer

### DIFF
--- a/lib/state/budget_providers.dart
+++ b/lib/state/budget_providers.dart
@@ -274,7 +274,7 @@ final periodToCloseProvider = Provider<PeriodRef?>((ref) {
     final now = DateTime.now();
     if (now.isBefore(hiddenUntil)) {
       final duration = hiddenUntil.difference(now);
-      if (duration.isPositive) {
+      if (duration > Duration.zero) {
         final timer = Timer(duration, ref.invalidateSelf);
         ref.onDispose(timer.cancel);
       }


### PR DESCRIPTION
## Summary
- replace the use of the non-existent `Duration.isPositive` getter with an explicit comparison to `Duration.zero`

## Testing
- `flutter analyze` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a883031c8326a57398a174a30e92