### PR TITLE
Update planned pool logic and plan defaults

### DIFF
--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -120,7 +120,7 @@ abstract class TransactionsRepository {
     DatabaseExecutor? executor,
   });
 
-  Future<int> sumIncludedPlannedExpenses({
+  Future<int> sumPlannedExpenses({
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
@@ -650,7 +650,7 @@ class SqliteTransactionsRepository implements TransactionsRepository {
   }
 
   @override
-  Future<int> sumIncludedPlannedExpenses({
+  Future<int> sumPlannedExpenses({
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
@@ -660,7 +660,7 @@ class SqliteTransactionsRepository implements TransactionsRepository {
     final rows = await db.rawQuery(
       'SELECT COALESCE(SUM(amount_minor), 0) AS total '
       'FROM transactions '
-      "WHERE is_planned = 1 AND included_in_period = 1 "
+      "WHERE is_planned = 1 "
       "AND type = 'expense' AND date >= ? AND date < ?",
       [_formatDate(start), _formatDate(endExclusive)],
     );

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -352,12 +352,12 @@ class _TransactionsRepositoryWithDbTick
   }
 
   @override
-  Future<int> sumIncludedPlannedExpenses({
+  Future<int> sumPlannedExpenses({
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
   }) {
-    return _delegate.sumIncludedPlannedExpenses(
+    return _delegate.sumPlannedExpenses(
       period: period,
       start: start,
       endExclusive: endExclusive,

--- a/lib/state/planned_providers.dart
+++ b/lib/state/planned_providers.dart
@@ -228,13 +228,13 @@ final plannedActionsProvider = Provider<PlannedActions>((ref) {
   return PlannedActions(repo);
 });
 
-final sumIncludedPlannedExpensesProvider =
+final sumPlannedExpensesProvider =
     FutureProvider.family<int, PeriodRef>((ref, period) async {
   ref.watch(dbTickProvider);
   ref.watch(selectedPeriodRefProvider);
   final entry = await ref.watch(periodEntryProvider(period).future);
   final repository = ref.watch(transactionsRepoProvider);
-  return repository.sumIncludedPlannedExpenses(
+  return repository.sumPlannedExpenses(
     period: period,
     start: entry.start,
     endExclusive: entry.endExclusive,
@@ -246,7 +246,7 @@ final plannedPoolRemainingProvider =
   ref.watch(dbTickProvider);
   ref.watch(selectedPeriodRefProvider);
   final base = await ref.watch(plannedPoolBaseProvider.future);
-  final used = await ref.watch(sumIncludedPlannedExpensesProvider(period).future);
+  final used = await ref.watch(sumPlannedExpensesProvider(period).future);
   final remaining = base - used;
   return math.max(remaining, 0);
 });

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -737,7 +737,7 @@ class _PlannedOverviewState extends ConsumerState<_PlannedOverview> {
     final period = ref.watch(selectedPeriodRefProvider);
     final baseAsync = ref.watch(plannedPoolBaseProvider);
     final remainingAsync = ref.watch(plannedPoolRemainingProvider(period));
-    final usedAsync = ref.watch(sumIncludedPlannedExpensesProvider(period));
+    final usedAsync = ref.watch(sumPlannedExpensesProvider(period));
     return payoutAsync.when(
       data: (payout) {
         if (payout == null) {

--- a/lib/ui/planned/expense_plan_sheets.dart
+++ b/lib/ui/planned/expense_plan_sheets.dart
@@ -136,7 +136,7 @@ class _QuickAddExpensePlanFormState
   late final TextEditingController _noteController;
   int? _categoryId;
   int? _necessityId;
-  bool _include = true;
+  bool _include = false;
   bool _isSaving = false;
   bool _restoredFromStorage = false;
 
@@ -400,7 +400,7 @@ class _QuickAddExpensePlanFormState
                   onChanged: _isSaving
                       ? null
                       : (value) {
-                          setState(() => _include = value ?? true);
+                          setState(() => _include = value ?? false);
                         },
                   title: const Text('Учитывать в расчёте'),
                   contentPadding: EdgeInsets.zero,
@@ -505,7 +505,7 @@ class _QuickAddExpensePlanFormState
     _noteController.text = (restored['note'] as String?) ?? '';
     _categoryId = restored['categoryId'] as int?;
     _necessityId = restored['necessityId'] as int?;
-    _include = restored['include'] as bool? ?? true;
+    _include = restored['include'] as bool? ?? false;
   }
 
   void _clearStoredFormState() {
@@ -991,7 +991,7 @@ class _AssignConfirmationSheet extends ConsumerStatefulWidget {
 class _AssignConfirmationSheetState
     extends ConsumerState<_AssignConfirmationSheet> {
   late final TextEditingController _noteController;
-  bool _include = true;
+  bool _include = false;
   int? _accountId;
   bool _accountInitialized = false;
 
@@ -1105,7 +1105,7 @@ class _AssignConfirmationSheetState
           CheckboxListTile(
             value: _include,
             onChanged: (value) {
-              setState(() => _include = value ?? true);
+              setState(() => _include = value ?? false);
             },
             title: const Text('Учитывать в расчёте'),
             contentPadding: EdgeInsets.zero,

--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -753,13 +753,13 @@ class _PlannedMasterEditFormState
   void _refreshBudgetSummaries(DateTime date) {
     final selectedPeriod = ref.read(selectedPeriodRefProvider);
     ref.invalidate(plannedPoolRemainingProvider(selectedPeriod));
-    ref.invalidate(sumIncludedPlannedExpensesProvider(selectedPeriod));
+    ref.invalidate(sumPlannedExpensesProvider(selectedPeriod));
 
     final anchors = ref.read(anchorDaysProvider);
     final period = periodRefForDate(date, anchors.$1, anchors.$2);
     if (!_isSamePeriod(period, selectedPeriod)) {
       ref.invalidate(plannedPoolRemainingProvider(period));
-      ref.invalidate(sumIncludedPlannedExpensesProvider(period));
+      ref.invalidate(sumPlannedExpensesProvider(period));
     }
   }
 

--- a/lib/ui/planned/planned_quick_add_sheet.dart
+++ b/lib/ui/planned/planned_quick_add_sheet.dart
@@ -48,7 +48,7 @@ class _PlannedQuickAddSheetState extends ConsumerState<_PlannedQuickAddSheet> {
   late final TextEditingController _noteController;
   int? _selectedCategoryId;
   int? _selectedNecessityId;
-  bool _included = true;
+  bool _included = false;
   bool _reuseExisting = true;
   bool _isSaving = false;
 
@@ -274,7 +274,7 @@ class _PlannedQuickAddSheetState extends ConsumerState<_PlannedQuickAddSheet> {
                         onChanged: _isSaving
                             ? null
                             : (value) {
-                                setState(() => _included = value ?? true);
+                                setState(() => _included = value ?? false);
                               },
                         title: const Text('Учитывать в расчёте'),
                         contentPadding: EdgeInsets.zero,

--- a/test/ui/planned_assign_sheet_test.dart
+++ b/test/ui/planned_assign_sheet_test.dart
@@ -165,7 +165,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
       _unsupported();
 
   @override
-  Future<int> sumIncludedPlannedExpenses({
+  Future<int> sumPlannedExpenses({
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,


### PR DESCRIPTION
## Summary
- include all planned expenses in the available-for-plans calculation and refresh dependents accordingly
- default new plans to be excluded from the period until explicitly checked, including quick add and assignment flows

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3a855ac5c8326b9e7ed206e111558