### PR TITLE
Ensure period close banner hides after closing

### DIFF
--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -207,6 +207,8 @@ class HomeScreen extends ConsumerWidget {
                             plannedIncludedMinor: planned,
                             carryoverMinor: 0,
                           );
+                          await ref
+                              .refresh(periodStatusProvider(periodRef).future);
                           read(selectedPeriodRefProvider.notifier).state =
                               periodRef.nextHalf();
                           bumpDbTick(ref);


### PR DESCRIPTION
## Summary
- refresh the period status after closing to force the close banner to disappear

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aa7171588326b69ba1c425b1b69f