### PR TITLE
Add plan domain models and riverpod providers

### DIFF
--- a/lib/data/models/plan.dart
+++ b/lib/data/models/plan.dart
@@ -1,0 +1,164 @@
+import 'package:meta/meta.dart';
+
+import '../../utils/period_utils.dart';
+
+@immutable
+class PlanMaster {
+  const PlanMaster({
+    required this.id,
+    required this.name,
+    required this.amount,
+    required this.categoryId,
+    this.criticalityId,
+    this.note,
+    required this.isActive,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final int id;
+  final String name;
+  final int amount;
+  final int categoryId;
+  final int? criticalityId;
+  final String? note;
+  final bool isActive;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  PlanMaster copyWith({
+    String? name,
+    int? amount,
+    int? categoryId,
+    Object? criticalityId = _sentinel,
+    Object? note = _sentinel,
+    bool? isActive,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return PlanMaster(
+      id: id,
+      name: name ?? this.name,
+      amount: amount ?? this.amount,
+      categoryId: categoryId ?? this.categoryId,
+      criticalityId: criticalityId == _sentinel
+          ? this.criticalityId
+          : criticalityId as int?,
+      note: note == _sentinel ? this.note : note as String?,
+      isActive: isActive ?? this.isActive,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        name,
+        amount,
+        categoryId,
+        criticalityId,
+        note,
+        isActive,
+        createdAt,
+        updatedAt,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    return other is PlanMaster &&
+        other.id == id &&
+        other.name == name &&
+        other.amount == amount &&
+        other.categoryId == categoryId &&
+        other.criticalityId == criticalityId &&
+        other.note == note &&
+        other.isActive == isActive &&
+        other.createdAt == createdAt &&
+        other.updatedAt == updatedAt;
+  }
+
+  static const Object _sentinel = Object();
+}
+
+@immutable
+class PlanInstance {
+  const PlanInstance({
+    required this.id,
+    required this.masterId,
+    required this.period,
+    this.overrideAmount,
+    this.accountId,
+    required this.includedInPeriod,
+    this.scheduledAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final int id;
+  final int masterId;
+  final PeriodRef period;
+  final int? overrideAmount;
+  final int? accountId;
+  final bool includedInPeriod;
+  final DateTime? scheduledAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  int resolveAmount(PlanMaster master) => overrideAmount ?? master.amount;
+
+  PlanInstance copyWith({
+    int? masterId,
+    PeriodRef? period,
+    Object? overrideAmount = _sentinel,
+    Object? accountId = _sentinel,
+    bool? includedInPeriod,
+    Object? scheduledAt = _sentinel,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return PlanInstance(
+      id: id,
+      masterId: masterId ?? this.masterId,
+      period: period ?? this.period,
+      overrideAmount: overrideAmount == _sentinel
+          ? this.overrideAmount
+          : overrideAmount as int?,
+      accountId: accountId == _sentinel ? this.accountId : accountId as int?,
+      includedInPeriod: includedInPeriod ?? this.includedInPeriod,
+      scheduledAt:
+          scheduledAt == _sentinel ? this.scheduledAt : scheduledAt as DateTime?,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        masterId,
+        period,
+        overrideAmount,
+        accountId,
+        includedInPeriod,
+        scheduledAt,
+        createdAt,
+        updatedAt,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    return other is PlanInstance &&
+        other.id == id &&
+        other.masterId == masterId &&
+        other.period == period &&
+        other.overrideAmount == overrideAmount &&
+        other.accountId == accountId &&
+        other.includedInPeriod == includedInPeriod &&
+        other.scheduledAt == scheduledAt &&
+        other.createdAt == createdAt &&
+        other.updatedAt == updatedAt;
+  }
+
+  static const Object _sentinel = Object();
+}

--- a/lib/state/plan_providers.dart
+++ b/lib/state/plan_providers.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/models/plan.dart';
+import '../data/models/transaction_record.dart';
+import '../data/repositories/planned_master_repository.dart';
+import '../data/repositories/transactions_repository.dart';
+import '../data/repositories/necessity_repository.dart' as necessity_repo;
+import '../utils/period_utils.dart';
+import 'app_providers.dart';
+import 'budget_providers.dart';
+import 'db_refresh.dart';
+
+PlanMaster _mapMaster(PlannedMaster source) {
+  final id = source.id;
+  if (id == null) {
+    throw StateError('Master without id cannot be mapped');
+  }
+  return PlanMaster(
+    id: id,
+    name: source.title.trim(),
+    amount: source.defaultAmountMinor ?? 0,
+    categoryId: source.categoryId ?? 0,
+    criticalityId: source.necessityId,
+    note: source.note,
+    isActive: !source.archived,
+    createdAt: source.createdAt,
+    updatedAt: source.updatedAt,
+  );
+}
+
+PlanInstance _mapInstance({
+  required TransactionRecord record,
+  required PlanMaster master,
+  required PeriodRef period,
+}) {
+  final override = record.amountMinor == master.amount ? null : record.amountMinor;
+  final scheduledAt = record.date;
+  return PlanInstance(
+    id: record.id ?? 0,
+    masterId: master.id,
+    period: period,
+    overrideAmount: override,
+    accountId: record.accountId,
+    includedInPeriod: record.includedInPeriod,
+    scheduledAt: scheduledAt,
+    createdAt: scheduledAt,
+    updatedAt: scheduledAt,
+  );
+}
+
+final planMasterProvider = FutureProvider.family<PlanMaster, int>((ref, id) async {
+  ref.watch(dbTickProvider);
+  final repository = ref.watch(plannedMasterRepoProvider);
+  final master = await repository.getById(id);
+  if (master == null) {
+    throw StateError('Не найден план с идентификатором $id');
+  }
+  return _mapMaster(master);
+});
+
+typedef PlanInstanceKey = ({int masterId, PeriodRef period});
+
+final planInstanceProvider =
+    FutureProvider.family<PlanInstance?, PlanInstanceKey>((ref, key) async {
+  ref.watch(dbTickProvider);
+  final master = await ref.watch(planMasterProvider(key.masterId).future);
+  final entry = await ref.watch(periodEntryProvider(key.period).future);
+  final transactionsRepo = ref.watch(transactionsRepoProvider);
+  final records = await transactionsRepo.listPlannedByPeriod(
+    start: entry.start,
+    endExclusive: entry.endExclusive,
+    type: 'expense',
+  );
+  for (final record in records) {
+    if (record.plannedId == master.id) {
+      return _mapInstance(record: record, master: master, period: key.period);
+    }
+  }
+  return null;
+});
+
+class PlanRowVm {
+  const PlanRowVm({
+    required this.masterId,
+    required this.title,
+    required this.amount,
+    required this.criticalityLabel,
+    required this.included,
+  });
+
+  final int masterId;
+  final String title;
+  final int amount;
+  final String? criticalityLabel;
+  final bool included;
+}
+
+final _necessityLabelsProvider = FutureProvider<Map<int, necessity_repo.NecessityLabel>>((ref) async {
+  final repository = ref.watch(necessityRepoProvider);
+  final labels = await repository.list(includeArchived: true);
+  return {
+    for (final label in labels) label.id: label,
+  };
+});
+
+final planRowsForPeriodProvider =
+    FutureProvider.family<List<PlanRowVm>, PeriodRef>((ref, period) async {
+  ref.watch(dbTickProvider);
+  final entry = await ref.watch(periodEntryProvider(period).future);
+  final transactionsRepo = ref.watch(transactionsRepoProvider);
+  final masterRepo = ref.watch(plannedMasterRepoProvider);
+  final necessityLabels = await ref.watch(_necessityLabelsProvider.future);
+  final masters = await masterRepo.list(includeArchived: true);
+  if (masters.isEmpty) {
+    return const [];
+  }
+  final masterMap = {
+    for (final master in masters)
+      if (master.id != null) master.id!: _mapMaster(master),
+  };
+  if (masterMap.isEmpty) {
+    return const [];
+  }
+  final records = await transactionsRepo.listPlannedByPeriod(
+    start: entry.start,
+    endExclusive: entry.endExclusive,
+    type: 'expense',
+  );
+  if (records.isEmpty) {
+    return const [];
+  }
+  final rows = <PlanRowVm>[];
+  for (final record in records) {
+    final plannedId = record.plannedId;
+    if (plannedId == null) {
+      continue;
+    }
+    final master = masterMap[plannedId];
+    if (master == null) {
+      continue;
+    }
+    final necessityId = master.criticalityId;
+    final label =
+        necessityId != null ? necessityLabels[necessityId]?.name : null;
+    rows.add(
+      PlanRowVm(
+        masterId: master.id,
+        title: master.name,
+        amount: record.amountMinor,
+        criticalityLabel: label,
+        included: record.includedInPeriod,
+      ),
+    );
+  }
+  rows.sort((a, b) {
+    final titleCompare = a.title.toLowerCase().compareTo(b.title.toLowerCase());
+    if (titleCompare != 0) {
+      return titleCompare;
+    }
+    return a.masterId.compareTo(b.masterId);
+  });
+  return rows;
+});


### PR DESCRIPTION
## Summary
- add immutable domain models that describe plan masters and their period instances
- provide riverpod helpers to load masters, instances, and period row view models from existing repositories

## Testing
- not run (Flutter/Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3d08e2ae88326a4ca5ff75300bfd2