### PR TITLE
Synchronize master plan updates across period instances

### DIFF
--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -14,8 +14,9 @@ import '../../state/db_refresh.dart';
 import '../../utils/formatting.dart';
 import '../../utils/period_utils.dart';
 import '../../utils/ru_plural.dart';
-import '../planned/planned_add_form.dart';
 import '../planned/expense_plan_sheets.dart';
+import '../planned/planned_add_form.dart';
+import '../planned/planned_master_edit_sheet.dart';
 import '../payouts/payout_edit_sheet.dart';
 import 'daily_limit_sheet.dart';
 import '../widgets/callout_card.dart';
@@ -892,12 +893,18 @@ class _PlannedExpensesList extends ConsumerWidget {
                         type: PlannedType.expense,
                         initialRecord: item.record,
                       ),
-                      onLongPress: () => showPlannedAddForm(
-                        context,
-                        type: PlannedType.expense,
-                        initialRecord: item.record,
-                        initialTitle: item.master?.title,
-                      ),
+                      onLongPress: () async {
+                        final master = item.master;
+                        if (master == null) {
+                          return;
+                        }
+                        await showPlannedMasterEditSheet(
+                          context,
+                          initial: master,
+                          successMessage:
+                              'План обновлён, периоды пересчитаны',
+                        );
+                      },
                     ),
                     if (index != items.length - 1) const Divider(height: 0),
                   ],

--- a/lib/ui/planned/planned_master_edit_sheet.dart
+++ b/lib/ui/planned/planned_master_edit_sheet.dart
@@ -22,6 +22,7 @@ import 'planned_assign_to_period_sheet.dart';
 Future<void> showPlannedMasterEditSheet(
   BuildContext context, {
   PlannedMaster? initial,
+  String? successMessage,
 }) {
   return showModalBottomSheet(
     context: context,
@@ -38,16 +39,20 @@ Future<void> showPlannedMasterEditSheet(
           top: 16,
           bottom: 16 + MediaQuery.of(modalContext).viewInsets.bottom,
         ),
-        child: _PlannedMasterEditForm(initial: initial),
+        child: _PlannedMasterEditForm(
+          initial: initial,
+          successMessage: successMessage,
+        ),
       );
     },
   );
 }
 
 class _PlannedMasterEditForm extends ConsumerStatefulWidget {
-  const _PlannedMasterEditForm({this.initial});
+  const _PlannedMasterEditForm({this.initial, this.successMessage});
 
   final PlannedMaster? initial;
+  final String? successMessage;
 
   @override
   ConsumerState<_PlannedMasterEditForm> createState() =>
@@ -354,7 +359,7 @@ class _PlannedMasterEditFormState
           return;
         }
         bumpDbTick(ref);
-        _showSnack('Сохранено');
+        _showSnack(widget.successMessage ?? 'Сохранено');
         Navigator.of(context).pop(true);
         return;
       }
@@ -376,7 +381,7 @@ class _PlannedMasterEditFormState
       }
       if (rows > 0) {
         bumpDbTick(ref);
-        _showSnack('Сохранено');
+        _showSnack(widget.successMessage ?? 'Сохранено');
         Navigator.of(context).pop(true);
       }
     } on ControlledOperationException catch (error) {


### PR DESCRIPTION
## Summary
- update planned transaction rows when a master plan is edited so that amount, category, necessity, and note stay in sync
- let the master plan edit sheet accept a custom success message and reuse it from the home screen
- invoke the master plan editor from the home planned list long-press flow to edit the shared master record

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d82510748326b070f5e703e66e3a