### PR TITLE
Align transactions with explicit period assignment

### DIFF
--- a/lib/data/models/transaction_record.dart
+++ b/lib/data/models/transaction_record.dart
@@ -24,6 +24,7 @@ class TransactionRecord {
     this.reasonLabel,
     this.source,
     this.payoutPeriodId,
+    this.periodId,
   });
 
   final int? id;
@@ -46,6 +47,7 @@ class TransactionRecord {
   final String? reasonLabel;
   final String? source;
   final String? payoutPeriodId;
+  final String? periodId;
 
   TransactionRecord copyWith({
     int? id,
@@ -68,6 +70,7 @@ class TransactionRecord {
     Object? reasonLabel = _unset,
     Object? source = _unset,
     Object? payoutPeriodId = _unset,
+    Object? periodId = _unset,
   }) {
     return TransactionRecord(
       id: id ?? this.id,
@@ -102,6 +105,7 @@ class TransactionRecord {
       payoutPeriodId: payoutPeriodId == _unset
           ? this.payoutPeriodId
           : payoutPeriodId as String?,
+      periodId: periodId == _unset ? this.periodId : periodId as String?,
     );
   }
 
@@ -127,6 +131,7 @@ class TransactionRecord {
       reasonLabel: map['reason_label'] as String?,
       source: map['source'] as String?,
       payoutPeriodId: map['payout_period_id'] as String?,
+      periodId: map['period_id'] as String?,
     );
   }
 
@@ -152,6 +157,7 @@ class TransactionRecord {
       'reason_label': reasonLabel,
       'source': source,
       'payout_period_id': payoutPeriodId,
+      'period_id': periodId,
     };
   }
 

--- a/lib/data/repositories/payouts_repository.dart
+++ b/lib/data/repositories/payouts_repository.dart
@@ -389,6 +389,7 @@ class SqlitePayoutsRepository implements PayoutsRepository {
       'tags': null,
       'payout_id': payoutId,
       'payout_period_id': assignedPeriodId,
+      'period_id': assignedPeriodId,
     };
 
     if (existing.isEmpty) {

--- a/lib/data/repositories/planned_instances_repository.dart
+++ b/lib/data/repositories/planned_instances_repository.dart
@@ -1,10 +1,12 @@
 import 'package:sqflite/sqflite.dart';
 
+import '../../utils/period_utils.dart';
 import '../db/app_database.dart';
 
 abstract class PlannedInstancesRepository {
   Future<void> assignMasterToPeriod({
     required int masterId,
+    required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
     required int categoryId,
@@ -55,6 +57,7 @@ class SqlitePlannedInstancesRepository implements PlannedInstancesRepository {
   @override
   Future<void> assignMasterToPeriod({
     required int masterId,
+    required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
     required int categoryId,
@@ -90,6 +93,7 @@ class SqlitePlannedInstancesRepository implements PlannedInstancesRepository {
           'reason_id': null,
           'reason_label': null,
           'payout_id': null,
+          'period_id': period.id,
         };
         await db.insert('transactions', values);
       },

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -158,12 +158,14 @@ class _TransactionsRepositoryWithDbTick
     transaction_models.TransactionRecord record, {
     bool asSavingPair = false,
     bool? includedInPeriod,
+    PeriodRef? uiPeriod,
     DatabaseExecutor? executor,
   }) async {
     final result = await _delegate.add(
       record,
       asSavingPair: asSavingPair,
       includedInPeriod: includedInPeriod,
+      uiPeriod: uiPeriod,
       executor: executor,
     );
     if (executor == null) {
@@ -175,6 +177,7 @@ class _TransactionsRepositoryWithDbTick
   @override
   Future<void> assignMasterToPeriod({
     required int masterId,
+    required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
     required int categoryId,
@@ -187,6 +190,7 @@ class _TransactionsRepositoryWithDbTick
   }) async {
     await _delegate.assignMasterToPeriod(
       masterId: masterId,
+      period: period,
       start: start,
       endExclusive: endExclusive,
       categoryId: categoryId,
@@ -308,12 +312,14 @@ class _TransactionsRepositoryWithDbTick
     required DateTime endExclusive,
     String? type,
     bool? onlyIncluded,
+    String? periodId,
   }) {
     return _delegate.listPlannedByPeriod(
       start: start,
       endExclusive: endExclusive,
       type: type,
       onlyIncluded: onlyIncluded,
+      periodId: periodId,
     );
   }
 
@@ -330,6 +336,7 @@ class _TransactionsRepositoryWithDbTick
     String? necessityLabel,
     bool includedInPeriod = false,
     int criticality = 0,
+    PeriodRef? period,
     DatabaseExecutor? executor,
   }) async {
     final result = await _delegate.createPlannedInstance(
@@ -344,6 +351,7 @@ class _TransactionsRepositoryWithDbTick
       necessityLabel: necessityLabel,
       includedInPeriod: includedInPeriod,
       criticality: criticality,
+      period: period,
       executor: executor,
     );
     if (executor == null) {
@@ -357,11 +365,13 @@ class _TransactionsRepositoryWithDbTick
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
+    String? periodId,
   }) {
     return _delegate.sumPlannedExpenses(
       period: period,
       start: start,
       endExclusive: endExclusive,
+      periodId: periodId,
     );
   }
 
@@ -417,11 +427,13 @@ class _TransactionsRepositoryWithDbTick
     required DateTime date,
     required DateTime periodStart,
     required DateTime periodEndExclusive,
+    String? periodId,
   }) {
     return _delegate.sumExpensesOnDateWithinPeriod(
       date: date,
       periodStart: periodStart,
       periodEndExclusive: periodEndExclusive,
+      periodId: periodId,
     );
   }
 
@@ -429,8 +441,13 @@ class _TransactionsRepositoryWithDbTick
   Future<int> sumUnplannedExpensesInRange(
     DateTime from,
     DateTime toExclusive,
+    {String? periodId,}
   ) {
-    return _delegate.sumUnplannedExpensesInRange(from, toExclusive);
+    return _delegate.sumUnplannedExpensesInRange(
+      from,
+      toExclusive,
+      periodId: periodId,
+    );
   }
 
   @override
@@ -438,11 +455,13 @@ class _TransactionsRepositoryWithDbTick
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
+    String? periodId,
   }) {
     return _delegate.sumActualExpenses(
       period: period,
       start: start,
       endExclusive: endExclusive,
+      periodId: periodId,
     );
   }
 
@@ -450,11 +469,13 @@ class _TransactionsRepositoryWithDbTick
   Future<void> update(
     transaction_models.TransactionRecord record, {
     bool? includedInPeriod,
+    PeriodRef? uiPeriod,
     DatabaseExecutor? executor,
   }) async {
     await _delegate.update(
       record,
       includedInPeriod: includedInPeriod,
+      uiPeriod: uiPeriod,
       executor: executor,
     );
     if (executor == null) {

--- a/lib/state/planned_master_providers.dart
+++ b/lib/state/planned_master_providers.dart
@@ -274,6 +274,7 @@ class PlannedFacade {
       }
       await _instancesRepository.assignMasterToPeriod(
         masterId: masterId,
+        period: period,
         start: bounds.start,
         endExclusive: bounds.endExclusive,
         categoryId: categoryId,

--- a/lib/state/planned_providers.dart
+++ b/lib/state/planned_providers.dart
@@ -238,6 +238,7 @@ final sumPlannedExpensesProvider =
     period: period,
     start: entry.start,
     endExclusive: entry.endExclusive,
+    periodId: period.id,
   );
 });
 

--- a/lib/ui/planned/expense_plan_sheets.dart
+++ b/lib/ui/planned/expense_plan_sheets.dart
@@ -941,6 +941,7 @@ class _SelectFromMasterSheetState
       final entry = await ref.read(periodEntryProvider(widget.period).future);
       await transactionsRepo.assignMasterToPeriod(
         masterId: master.id,
+        period: widget.period,
         start: entry.start,
         endExclusive: entry.endExclusive,
         categoryId: categoryId,

--- a/lib/ui/planned/planned_assign_to_period_sheet.dart
+++ b/lib/ui/planned/planned_assign_to_period_sheet.dart
@@ -516,6 +516,7 @@ class _PlannedAssignToPeriodFormState
           necessityLabel: necessityLabel,
           includedInPeriod: _included,
           criticality: criticality,
+          period: ref.read(selectedPeriodRefProvider),
         );
       } else {
         final updated = existing.copyWith(
@@ -529,7 +530,10 @@ class _PlannedAssignToPeriodFormState
           necessityLabel: necessityLabel,
           criticality: criticality,
         );
-        await repo.update(updated);
+        await repo.update(
+          updated,
+          uiPeriod: ref.read(selectedPeriodRefProvider),
+        );
       }
       if (!mounted) {
         return;

--- a/test/data/repositories/transactions_repository_test.dart
+++ b/test/data/repositories/transactions_repository_test.dart
@@ -18,6 +18,7 @@ void main() {
   late int accountId;
   late int categoryId;
   late AccountsRepository accountsRepository;
+  const anchors = (1, 15);
 
   String formatDate(DateTime date) {
     final month = date.month.toString().padLeft(2, '0');
@@ -30,7 +31,10 @@ void main() {
     required int amountMinor,
     required bool included,
     bool planned = false,
+    PeriodRef? period,
   }) async {
+    final resolvedPeriod =
+        period ?? periodRefForDate(date, anchors.$1, anchors.$2);
     await db.insert('transactions', {
       'account_id': accountId,
       'category_id': categoryId,
@@ -39,6 +43,7 @@ void main() {
       'date': formatDate(date),
       'is_planned': planned ? 1 : 0,
       'included_in_period': included ? 1 : 0,
+      'period_id': resolvedPeriod.id,
     });
   }
 
@@ -86,6 +91,7 @@ void main() {
 
     await repository.assignMasterToPeriod(
       masterId: masterId,
+      period: const PeriodRef(year: 2024, month: 1, half: HalfPeriod.first),
       start: start,
       endExclusive: endExclusive,
       categoryId: categoryId,
@@ -164,9 +170,11 @@ void main() {
       planned: true,
     );
 
+    const period = PeriodRef(year: 2024, month: 1, half: HalfPeriod.first);
     final total = await repository.sumUnplannedExpensesInRange(
       start,
       start.add(const Duration(days: 3)),
+      periodId: period.id,
     );
 
     expect(total, 1200);
@@ -225,10 +233,12 @@ void main() {
       included: true,
     );
 
+    const period = PeriodRef(year: 2024, month: 1, half: HalfPeriod.first);
     final total = await repository.sumExpensesOnDateWithinPeriod(
       date: targetDate,
       periodStart: periodStart,
       periodEndExclusive: periodEndExclusive,
+      periodId: period.id,
     );
 
     expect(total, 1_500);
@@ -270,6 +280,7 @@ void main() {
       period: period,
       start: periodStart,
       endExclusive: periodEndExclusive,
+      periodId: period.id,
     );
 
     expect(total, 1_300);

--- a/test/state/operations_filters_test.dart
+++ b/test/state/operations_filters_test.dart
@@ -37,6 +37,7 @@ class _FakeTransactionsRepository implements TransactionsRepository {
     bool? isPlanned,
     bool? includedInPeriod,
     bool aggregateSavingPairs = false,
+    String? periodId,
   }) async {
     final key = requestKey(from, to);
     return responses[key] ?? const [];

--- a/test/ui/planned_assign_sheet_test.dart
+++ b/test/ui/planned_assign_sheet_test.dart
@@ -25,6 +25,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
   @override
   Future<void> assignMasterToPeriod({
     required int masterId,
+    required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
     required int categoryId,
@@ -47,6 +48,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     TransactionRecord record, {
     bool asSavingPair = false,
     bool? includedInPeriod,
+    PeriodRef? uiPeriod,
     DatabaseExecutor? executor,
   }) => _unsupported();
 
@@ -81,6 +83,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     TransactionType? type,
     bool? isPlanned,
     bool? includedInPeriod,
+    String? periodId,
   }) =>
       _unsupported();
 
@@ -94,6 +97,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     bool? isPlanned,
     bool? includedInPeriod,
     bool aggregateSavingPairs = false,
+    String? periodId,
   }) =>
       _unsupported();
 
@@ -110,6 +114,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     required DateTime endExclusive,
     String? type,
     bool? onlyIncluded,
+    String? periodId,
   }) =>
       _unsupported();
 
@@ -126,6 +131,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     String? necessityLabel,
     bool includedInPeriod = false,
     int criticality = 0,
+    PeriodRef? period,
     DatabaseExecutor? executor,
   }) =>
       _unsupported();
@@ -153,6 +159,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
+    String? periodId,
   }) =>
       _unsupported();
 
@@ -161,6 +168,7 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     required DateTime date,
     required DateTime periodStart,
     required DateTime periodEndExclusive,
+    String? periodId,
   }) =>
       _unsupported();
 
@@ -169,12 +177,14 @@ class _RecordingTransactionsRepository implements TransactionsRepository {
     required PeriodRef period,
     required DateTime start,
     required DateTime endExclusive,
+    String? periodId,
   }) =>
       _unsupported();
 
   @override
   Future<int> sumUnplannedExpensesInRange(
-          DateTime from, DateTime toExclusive) =>
+          DateTime from, DateTime toExclusive,
+          {String? periodId}) =>
       _unsupported();
 
   @override


### PR DESCRIPTION
## Summary
- add a `period_id` column to transactions with migration/backfill and extend the transaction model
- persist the UI-selected period during operation creation/updates and rely on it in repository queries and metrics
- update entry and planning flows to respect the chosen period, handle closed-period prompts, and warn when dates are outside bounds

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3d6e0157c832693055e973b85ee50