### PR TITLE
Track period-origin operations

### DIFF
--- a/lib/state/entry_flow_providers.dart
+++ b/lib/state/entry_flow_providers.dart
@@ -52,6 +52,7 @@ class EntryFlowState {
     this.editingCounterpart,
     this.reasonId,
     this.reasonLabel,
+    this.includeInPeriod = false,
   }) : selectedDate = selectedDate ?? _today;
 
   final String expression;
@@ -71,6 +72,7 @@ class EntryFlowState {
   final TransactionRecord? editingCounterpart;
   final int? reasonId;
   final String? reasonLabel;
+  final bool includeInPeriod;
 
   static DateTime get _today {
     final now = DateTime.now();
@@ -101,6 +103,7 @@ class EntryFlowState {
     Object? editingCounterpart = _entryFlowUnset,
     Object? reasonId = _entryFlowUnset,
     Object? reasonLabel = _entryFlowUnset,
+    Object? includeInPeriod = _entryFlowUnset,
   }) {
     return EntryFlowState(
       expression:
@@ -139,6 +142,9 @@ class EntryFlowState {
       reasonLabel: reasonLabel == _entryFlowUnset
           ? this.reasonLabel
           : reasonLabel as String?,
+      includeInPeriod: includeInPeriod == _entryFlowUnset
+          ? this.includeInPeriod
+          : includeInPeriod as bool,
     );
   }
 
@@ -150,8 +156,11 @@ class EntryFlowState {
 class EntryFlowController extends StateNotifier<EntryFlowState> {
   EntryFlowController() : super(EntryFlowState());
 
-  void startNew({CategoryType type = CategoryType.expense}) {
-    state = EntryFlowState(type: type);
+  void startNew({
+    CategoryType type = CategoryType.expense,
+    bool includeInPeriod = false,
+  }) {
+    state = EntryFlowState(type: type, includeInPeriod: includeInPeriod);
   }
 
   void appendDigit(String digit) {
@@ -382,6 +391,7 @@ class EntryFlowController extends StateNotifier<EntryFlowState> {
       editingCounterpart: savingCounterpart,
       reasonId: record.reasonId,
       reasonLabel: record.reasonLabel,
+      includeInPeriod: record.includedInPeriod,
     );
   }
 

--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -452,6 +452,8 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
             )
           : null;
 
+      final includeInPeriod = entryState.includeInPeriod && inCurrent;
+
       final record = isEditingOperation
           ? editingRecord!.copyWith(
               accountId: accountId,
@@ -461,7 +463,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
               date: normalizedDate,
               note: note,
               isPlanned: isPlannedExpense,
-              includedInPeriod: isPlannedExpense ? false : inCurrent,
+              includedInPeriod: isPlannedExpense ? false : includeInPeriod,
               criticality: necessityCriticality,
               necessityId: necessityId,
               necessityLabel: necessityLabel,
@@ -477,7 +479,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
               date: normalizedDate,
               note: note,
               isPlanned: isPlannedExpense,
-              includedInPeriod: isPlannedExpense ? false : inCurrent,
+              includedInPeriod: isPlannedExpense ? false : includeInPeriod,
               criticality: necessityCriticality,
               necessityId: necessityId,
               necessityLabel: necessityLabel,
@@ -521,7 +523,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
       if (isEditingOperation) {
         await transactionsRepository.update(
           record,
-          includedInPeriod: isPlannedExpense ? null : inCurrent,
+          includedInPeriod: isPlannedExpense ? null : includeInPeriod,
           uiPeriod: selectedPeriod,
         );
         if (editingCounterpart != null) {
@@ -530,7 +532,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
             date: normalizedDate,
             note: note,
             isPlanned: isPlannedExpense,
-            includedInPeriod: isPlannedExpense ? false : inCurrent,
+            includedInPeriod: isPlannedExpense ? false : includeInPeriod,
             criticality: necessityCriticality,
             necessityId: necessityId,
             necessityLabel: necessityLabel,
@@ -540,7 +542,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
           );
           await transactionsRepository.update(
             updatedCounterpart,
-            includedInPeriod: isPlannedExpense ? null : inCurrent,
+            includedInPeriod: isPlannedExpense ? null : includeInPeriod,
             uiPeriod: selectedPeriod,
           );
         }
@@ -548,7 +550,7 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
         await transactionsRepository.add(
           record,
           asSavingPair: entryState.type == CategoryType.saving,
-          includedInPeriod: isPlannedExpense ? null : inCurrent,
+          includedInPeriod: isPlannedExpense ? null : includeInPeriod,
           uiPeriod: selectedPeriod,
         );
       }

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -112,7 +112,7 @@ class HomeScreen extends ConsumerWidget {
           ? null
           : _OvalFab(
               onPressed: () {
-                entryController.startNew();
+                entryController.startNew(includeInPeriod: true);
                 context.pushNamed(RouteNames.entryAmount);
               },
             ),


### PR DESCRIPTION
## Summary
- add entry flow state tracking to remember when an operation was started from the period home screen
- only mark saved transactions as period operations when they originate from the home screen and fall within the period bounds

## Testing
- `flutter test test/state/operations_filters_test.dart` *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e40a70db8c8326a73a7c561dff1462