### PR TITLE
Fix sumExpenses override signature

### DIFF
--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -785,6 +785,7 @@ class SqliteTransactionsRepository implements TransactionsRepository {
     required DateTime date,
     required DateTime periodStart,
     required DateTime periodEndExclusive,
+    String? periodId,
   }) async {
     final normalizedDate = DateTime(date.year, date.month, date.day);
     final normalizedStart = DateTime(


### PR DESCRIPTION
## Summary
- add the `periodId` optional parameter to the SqliteTransactionsRepository override so it matches the abstract definition

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c899da448326a4d6c7dd5bc09224