### PR TITLE
Keep out-of-range entries in selected period

### DIFF
--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -435,7 +435,11 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
       final isDateOutside = normalizedDate.isBefore(normalizedStart) ||
           !normalizedDate.isBefore(normalizedEndExclusive);
       final (anchor1, anchor2) = ref.read(anchorDaysProvider);
-      final targetPeriod = periodRefForDate(normalizedDate, anchor1, anchor2);
+      final selectedPeriod = ref.read(selectedPeriodRefProvider);
+      var targetPeriod = periodRefForDate(normalizedDate, anchor1, anchor2);
+      if (isDateOutside) {
+        targetPeriod = selectedPeriod;
+      }
       if (isDateOutside && mounted) {
         final targetBounds = targetPeriod.bounds(anchor1, anchor2);
         final targetLabel = compactPeriodLabel(


### PR DESCRIPTION
## Summary
- ensure that saving an entry outside the selected period keeps it bound to the originally selected period
- keep user feedback when the chosen date falls outside the selected bounds

## Testing
- not run (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e4cb2b25988326bcf385164067d308