### PR TITLE
Center calculator callout and enlarge quick amount buttons

### DIFF
--- a/lib/ui/entry/amount_screen.dart
+++ b/lib/ui/entry/amount_screen.dart
@@ -27,9 +27,9 @@ class AmountScreen extends ConsumerWidget {
     final showResultRow = hasOperators && (previewResult != null || result != null);
     final resultDisplay = formatCurrency(result ?? previewResult ?? amountValue);
     final quickButtonStyle = OutlinedButton.styleFrom(
-      minimumSize: const Size(0, 36),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      textStyle: const TextStyle(fontSize: 13),
+      minimumSize: const Size(0, 44),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
     );
 
     void handleNext() {
@@ -92,12 +92,13 @@ class AmountScreen extends ConsumerWidget {
                 ],
               ),
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   Text(
                     expressionDisplay,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 14,
                       height: 1.2,
@@ -107,6 +108,7 @@ class AmountScreen extends ConsumerWidget {
                   const SizedBox(height: 8),
                   Text(
                     formattedAmount,
+                    textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.displaySmall?.copyWith(
                           fontSize: 30,
                           fontWeight: FontWeight.w700,
@@ -131,8 +133,9 @@ class AmountScreen extends ConsumerWidget {
             ],
             const SizedBox(height: 12),
             Wrap(
-              spacing: 8,
-              runSpacing: 8,
+              spacing: 12,
+              runSpacing: 12,
+              alignment: WrapAlignment.center,
               children: [
                 OutlinedButton(
                   onPressed: () => controller.addQuickAmount(100),


### PR DESCRIPTION
## Summary
- center the calculator callout text for a more balanced appearance
- enlarge and center the quick amount buttons to improve usability

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f9d1b05c8326a53a01380b3a2120