### PR TITLE
Add configurable default account for new entries

### DIFF
--- a/lib/data/bootstrap/app_bootstrapper.dart
+++ b/lib/data/bootstrap/app_bootstrapper.dart
@@ -91,6 +91,24 @@ class AppBootstrapper {
       'saving_pair_enabled': '1',
     };
 
+    final cardAccountId = Sqflite.firstIntValue(
+      await executor.rawQuery(
+        'SELECT id FROM accounts WHERE LOWER(name) = ? ORDER BY id LIMIT 1',
+        ['карта'],
+      ),
+    );
+
+    final fallbackAccountId = cardAccountId ??
+        Sqflite.firstIntValue(
+          await executor.rawQuery(
+            'SELECT id FROM accounts ORDER BY id LIMIT 1',
+          ),
+        );
+
+    if (fallbackAccountId != null) {
+      defaults['default_account_id'] = '$fallbackAccountId';
+    }
+
     for (final entry in defaults.entries) {
       await executor.insert(
         'settings',

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -31,6 +31,10 @@ abstract class SettingsRepository {
   Future<DateTime?> getPeriodCloseBannerHiddenUntil();
 
   Future<void> setPeriodCloseBannerHiddenUntil(DateTime? value);
+
+  Future<int?> getDefaultAccountId();
+
+  Future<void> setDefaultAccountId(int? value);
 }
 
 class SqliteSettingsRepository implements SettingsRepository {
@@ -45,6 +49,7 @@ class SqliteSettingsRepository implements SettingsRepository {
   static const String _manualBackupHistoryKey = 'manual_backup_history';
   static const String _periodCloseBannerHiddenUntilKey =
       'period_close_banner_hidden_until';
+  static const String _defaultAccountIdKey = 'default_account_id';
 
   final AppDatabase _database;
 
@@ -131,6 +136,13 @@ class SqliteSettingsRepository implements SettingsRepository {
       value.toIso8601String(),
     );
   }
+
+  @override
+  Future<int?> getDefaultAccountId() => _getNullableInt(_defaultAccountIdKey);
+
+  @override
+  Future<void> setDefaultAccountId(int? value) =>
+      _setNullableInt(_defaultAccountIdKey, value);
 
   Future<int> _getInt(String key, {required int defaultValue}) async {
     final db = await _db;

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -129,6 +129,11 @@ final settingsRepoProvider = Provider<settings_repo.SettingsRepository>((ref) {
   return settings_repo.SqliteSettingsRepository(database: database);
 });
 
+final defaultAccountIdProvider = FutureProvider<int?>((ref) async {
+  final repository = ref.watch(settingsRepoProvider);
+  return repository.getDefaultAccountId();
+});
+
 final necessityRepoProvider = Provider<necessity_repo.NecessityRepository>((ref) {
   final database = ref.watch(appDatabaseProvider);
   return necessity_repo.NecessityRepositorySqlite(database: database);


### PR DESCRIPTION
## Summary
- store a default account id in settings during bootstrap and expose it through the settings repository
- preselect the configured default account in the entry review flow whenever no explicit account is set
- add a settings tile that lets users pick which active account should be used by default

## Testing
- not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4fd78ed1c83269399c1d4b861c7d7