### PR TITLE
Fix default account selection on review screen

### DIFF
--- a/lib/ui/entry/review_screen.dart
+++ b/lib/ui/entry/review_screen.dart
@@ -83,8 +83,11 @@ class _ReviewScreenState extends ConsumerState<ReviewScreen> {
       });
     }
     _reasonValidationError = false;
+    final accountsSnapshot = ref.read(activeAccountsProvider);
+    accountsSnapshot.whenData(_handleAccountsLoaded);
     final defaultAccountSnapshot = ref.read(defaultAccountIdProvider);
     _defaultAccountId = defaultAccountSnapshot.valueOrNull;
+    _applyDefaultAccountIfAvailable();
     _entryFlowSubscription = ref.listenManual<EntryFlowState>(
       entryFlowControllerProvider,
       (previous, next) {


### PR DESCRIPTION
## Summary
- eagerly read the cached accounts list when the review screen initializes
- apply the default account immediately so the dropdown always shows the preferred choice

## Testing
- `flutter test` *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e503a2e0848326948e6e292f040902