### PR TITLE
Add idempotent database seeding for default data

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -1,6 +1,7 @@
 import 'package:sqflite/sqflite.dart';
 
 import '../../utils/period_utils.dart';
+import '../seed/seed_data.dart';
 
 /// Defines all database migrations for the application.
 class AppMigrations {
@@ -288,6 +289,8 @@ class AppMigrations {
           break;
       }
     }
+
+    await SeedData.run(db);
   }
 
   static Future<void> _backfillTransactionPeriods(Database db) async {
@@ -447,19 +450,20 @@ class AppMigrations {
         .whereType<String>());
 
     if (labels.isEmpty) {
-      addUnique(_legacyDefaultNecessityLabels);
-    }
-    if (labels.isEmpty) {
-      addUnique(_fallbackNecessityLabels);
+      return;
     }
 
     for (var i = 0; i < labels.length; i++) {
-      await db.insert('necessity_labels', {
-        'name': labels[i],
-        'color': null,
-        'sort_order': i,
-        'archived': 0,
-      });
+      await db.insert(
+        'necessity_labels',
+        {
+          'name': labels[i],
+          'color': null,
+          'sort_order': i,
+          'archived': 0,
+        },
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
     }
   }
 
@@ -476,18 +480,6 @@ class AppMigrations {
     return 0;
   }
 
-  static const List<String> _legacyDefaultNecessityLabels = [
-    'Необходимо',
-    'Вынуждено',
-    'Эмоции',
-  ];
-
-  static const List<String> _fallbackNecessityLabels = [
-    'точно',
-    'надо',
-    'можно отложить',
-  ];
-
   static Future<void> _seedReasonLabels(Database db) async {
     final existingCountResult =
         await db.rawQuery('SELECT COUNT(*) AS count FROM reason_labels');
@@ -501,7 +493,7 @@ class AppMigrations {
     const defaultReasons = [
       'Необходимо',
       'Эмоции',
-      'Вынуждено',
+      'Вынужденно',
       'Социальное',
       'Импульс',
       'Статус',
@@ -509,12 +501,16 @@ class AppMigrations {
     ];
 
     for (var i = 0; i < defaultReasons.length; i++) {
-      await db.insert('reason_labels', {
-        'name': defaultReasons[i],
-        'color': null,
-        'sort_order': i,
-        'archived': 0,
-      });
+      await db.insert(
+        'reason_labels',
+        {
+          'name': defaultReasons[i],
+          'color': null,
+          'sort_order': i,
+          'archived': 0,
+        },
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
     }
   }
 }

--- a/lib/data/seed/seed_data.dart
+++ b/lib/data/seed/seed_data.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/foundation.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Seeds default reference data for the application.
+class SeedData {
+  SeedData._();
+
+  static Future<void> run(Database db) async {
+    assert(() {
+      debugPrint('[seed] ensuring defaults');
+      return true;
+    }());
+
+    await seedCategories(db);
+    await seedCriticalities(db);
+    await seedReasons(db);
+  }
+
+  static Future<void> seedCategories(DatabaseExecutor executor) async {
+    assert(() {
+      debugPrint('[seed] categories');
+      return true;
+    }());
+
+    final hasSortOrder = await _hasColumn(executor, 'categories', 'sort_order');
+    final folders = <String, int>{};
+
+    Future<int?> findCategoryId({
+      required String name,
+      required bool isGroup,
+      int? parentId,
+    }) async {
+      final whereBuffer = StringBuffer('type = ? AND name = ? AND is_group = ?');
+      final args = <Object?>['expense', name, isGroup ? 1 : 0];
+      if (parentId == null) {
+        whereBuffer.write(' AND parent_id IS NULL');
+      } else {
+        whereBuffer.write(' AND parent_id = ?');
+        args.add(parentId);
+      }
+      final rows = await executor.query(
+        'categories',
+        columns: ['id'],
+        where: whereBuffer.toString(),
+        whereArgs: args,
+        limit: 1,
+      );
+      if (rows.isEmpty) {
+        return null;
+      }
+      return rows.first['id'] as int?;
+    }
+
+    Future<int> ensureFolder(String name, int sortOrder) async {
+      final existingId = await findCategoryId(name: name, isGroup: true);
+      if (existingId != null) {
+        return existingId;
+      }
+
+      final values = <String, Object?>{
+        'type': 'expense',
+        'name': name,
+        'is_group': 1,
+        'parent_id': null,
+        'archived': 0,
+      };
+      if (hasSortOrder) {
+        values['sort_order'] = sortOrder;
+      }
+
+      final insertedId = await executor.insert(
+        'categories',
+        values,
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+      if (insertedId != 0) {
+        return insertedId;
+      }
+      final fallbackId = await findCategoryId(name: name, isGroup: true);
+      if (fallbackId != null) {
+        return fallbackId;
+      }
+      throw StateError('Failed to ensure folder "$name"');
+    }
+
+    Future<void> ensureChild(String folderName, String name, int sortOrder) async {
+      final parentId = folders[folderName];
+      if (parentId == null) {
+        throw StateError('Parent folder "$folderName" has not been created');
+      }
+      final existingId = await findCategoryId(
+        name: name,
+        isGroup: false,
+        parentId: parentId,
+      );
+      if (existingId != null) {
+        return;
+      }
+
+      final values = <String, Object?>{
+        'type': 'expense',
+        'name': name,
+        'is_group': 0,
+        'parent_id': parentId,
+        'archived': 0,
+      };
+      if (hasSortOrder) {
+        values['sort_order'] = sortOrder;
+      }
+
+      await executor.insert(
+        'categories',
+        values,
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+    }
+
+    const foldersDefinition = <_FolderDefinition>[
+      _FolderDefinition('Дом и быт', [
+        'Бытовое',
+        'ЖКХ и т.д.',
+      ]),
+      _FolderDefinition('Цифровое', [
+        'Игры',
+        'Подписки',
+        'Связь и интернет',
+      ]),
+      _FolderDefinition('Одежда', [
+        'Одежда и обувь',
+      ]),
+      _FolderDefinition('Базовые расходы', [
+        'Питание',
+        'Транспорт',
+        'Здоровье',
+        'Образование',
+      ]),
+      _FolderDefinition('Досуг', [
+        'Развлечения',
+        'Хобби',
+        'Путешествия',
+      ]),
+      _FolderDefinition('Подарки', [
+        'Подарки',
+      ]),
+      _FolderDefinition('Финансы', [
+        'Долг',
+        'Кредиты',
+      ]),
+    ];
+
+    for (var i = 0; i < foldersDefinition.length; i++) {
+      final folder = foldersDefinition[i];
+      final sortBase = (i + 1) * 100;
+      final folderId = await ensureFolder(folder.name, sortBase);
+      folders[folder.name] = folderId;
+      for (var j = 0; j < folder.children.length; j++) {
+        await ensureChild(folder.name, folder.children[j], sortBase + j + 1);
+      }
+    }
+  }
+
+  static Future<void> seedCriticalities(DatabaseExecutor executor) async {
+    assert(() {
+      debugPrint('[seed] criticalities');
+      return true;
+    }());
+
+    final hasColor = await _hasColumn(executor, 'necessity_labels', 'color');
+    final hasSortOrder = await _hasColumn(executor, 'necessity_labels', 'sort_order');
+
+    const items = <_LabelDefinition>[
+      _LabelDefinition('Точно', '#546E7A'),
+      _LabelDefinition('Надо', '#607D8B'),
+      _LabelDefinition('Можно отложить', '#78909C'),
+      _LabelDefinition('Заморожено', '#90A4AE'),
+      _LabelDefinition('Уже не надо', '#B0BEC5'),
+      _LabelDefinition('Хочу', '#CFD8DC'),
+    ];
+
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      final existingId = await _getSimpleId(
+        executor,
+        table: 'necessity_labels',
+        name: item.name,
+      );
+      if (existingId != null) {
+        continue;
+      }
+
+      final values = <String, Object?>{
+        'name': item.name,
+        'archived': 0,
+      };
+      if (hasColor) {
+        values['color'] = item.color;
+      }
+      if (hasSortOrder) {
+        values['sort_order'] = (i + 1) * 10;
+      }
+
+      await executor.insert(
+        'necessity_labels',
+        values,
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+    }
+  }
+
+  static Future<void> seedReasons(DatabaseExecutor executor) async {
+    assert(() {
+      debugPrint('[seed] reasons');
+      return true;
+    }());
+
+    final hasSortOrder = await _hasColumn(executor, 'reason_labels', 'sort_order');
+
+    const reasons = <String>[
+      'Необходимо',
+      'Эмоции',
+      'Вынужденно',
+      'Социальное',
+      'Импульс',
+      'Статус',
+      'Избегание',
+    ];
+
+    for (var i = 0; i < reasons.length; i++) {
+      final name = reasons[i];
+      final existingId = await _getSimpleId(
+        executor,
+        table: 'reason_labels',
+        name: name,
+      );
+      if (existingId != null) {
+        continue;
+      }
+
+      final values = <String, Object?>{
+        'name': name,
+        'color': null,
+        'archived': 0,
+      };
+      if (hasSortOrder) {
+        values['sort_order'] = (i + 1) * 10;
+      }
+
+      await executor.insert(
+        'reason_labels',
+        values,
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+    }
+  }
+
+  static Future<int?> _getSimpleId(
+    DatabaseExecutor executor, {
+    required String table,
+    required String name,
+  }) async {
+    final rows = await executor.query(
+      table,
+      columns: ['id'],
+      where: 'name = ?',
+      whereArgs: [name],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return rows.first['id'] as int?;
+  }
+
+  static Future<bool> _hasColumn(
+    DatabaseExecutor executor,
+    String table,
+    String column,
+  ) async {
+    final normalized = column.toLowerCase();
+    final result = await executor.rawQuery('PRAGMA table_info($table)');
+    return result.any((row) => (row['name'] as String?)?.toLowerCase() == normalized);
+  }
+}
+
+class _FolderDefinition {
+  const _FolderDefinition(this.name, this.children);
+
+  final String name;
+  final List<String> children;
+}
+
+class _LabelDefinition {
+  const _LabelDefinition(this.name, this.color);
+
+  final String name;
+  final String color;
+}


### PR DESCRIPTION
## Summary
- add a centralized SeedData helper to populate default categories, criticalities, and reasons idempotently
- invoke the seed helper from migrations and category restoration to keep defaults up to date without overwriting user changes

## Testing
- flutter test *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e51123e4848326aba01f689a46e8dc