### PR TITLE
Show default necessity settings in UI

### DIFF
--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -28,6 +28,14 @@ abstract class SettingsRepository {
 
   Future<void> addManualBackupEntry(ManualBackupEntry entry);
 
+  Future<int> getDefaultNecessityCriticality();
+
+  Future<void> setDefaultNecessityCriticality(int value);
+
+  Future<int?> getDefaultNecessityId();
+
+  Future<void> setDefaultNecessityId(int? value);
+
   Future<DateTime?> getPeriodCloseBannerHiddenUntil();
 
   Future<void> setPeriodCloseBannerHiddenUntil(DateTime? value);
@@ -50,6 +58,9 @@ class SqliteSettingsRepository implements SettingsRepository {
   static const String _periodCloseBannerHiddenUntilKey =
       'period_close_banner_hidden_until';
   static const String _defaultAccountIdKey = 'default_account_id';
+  static const String _defaultNecessityCriticalityKey =
+      'default_necessity_criticality';
+  static const String _defaultNecessityIdKey = 'default_necessity_id';
 
   final AppDatabase _database;
 
@@ -143,6 +154,22 @@ class SqliteSettingsRepository implements SettingsRepository {
   @override
   Future<void> setDefaultAccountId(int? value) =>
       _setNullableInt(_defaultAccountIdKey, value);
+
+  @override
+  Future<int> getDefaultNecessityCriticality() =>
+      _getInt(_defaultNecessityCriticalityKey, defaultValue: 0);
+
+  @override
+  Future<void> setDefaultNecessityCriticality(int value) =>
+      _setInt(_defaultNecessityCriticalityKey, value);
+
+  @override
+  Future<int?> getDefaultNecessityId() =>
+      _getNullableInt(_defaultNecessityIdKey);
+
+  @override
+  Future<void> setDefaultNecessityId(int? value) =>
+      _setNullableInt(_defaultNecessityIdKey, value);
 
   Future<int> _getInt(String key, {required int defaultValue}) async {
     final db = await _db;

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -134,6 +134,16 @@ final defaultAccountIdProvider = FutureProvider<int?>((ref) async {
   return repository.getDefaultAccountId();
 });
 
+final defaultNecessityCriticalityProvider = FutureProvider<int>((ref) async {
+  final repository = ref.watch(settingsRepoProvider);
+  return repository.getDefaultNecessityCriticality();
+});
+
+final defaultNecessityIdProvider = FutureProvider<int?>((ref) async {
+  final repository = ref.watch(settingsRepoProvider);
+  return repository.getDefaultNecessityId();
+});
+
 final necessityRepoProvider = Provider<necessity_repo.NecessityRepository>((ref) {
   final database = ref.watch(appDatabaseProvider);
   return necessity_repo.NecessityRepositorySqlite(database: database);


### PR DESCRIPTION
## Summary
- add storage APIs for default necessity criticality and label
- expose providers for the default necessity values
- render defaults card with pickers on the necessity settings screen

## Testing
- not run (flutter command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e51cc3a0d083268ba4d3340a048722