### PR TITLE
Remove default necessity options

### DIFF
--- a/lib/data/db/migrations.dart
+++ b/lib/data/db/migrations.dart
@@ -450,19 +450,6 @@ class AppMigrations {
         .whereType<String>());
 
     if (labels.isEmpty) {
-      const defaultLabels = [
-        'Точно',
-        'Надо',
-        'Можно отложить',
-        'Заморожено',
-        'Уже не надо',
-        'Хочу',
-      ];
-
-      addUnique(defaultLabels);
-    }
-
-    if (labels.isEmpty) {
       return;
     }
 

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -28,14 +28,6 @@ abstract class SettingsRepository {
 
   Future<void> addManualBackupEntry(ManualBackupEntry entry);
 
-  Future<int> getDefaultNecessityCriticality();
-
-  Future<void> setDefaultNecessityCriticality(int value);
-
-  Future<int?> getDefaultNecessityId();
-
-  Future<void> setDefaultNecessityId(int? value);
-
   Future<DateTime?> getPeriodCloseBannerHiddenUntil();
 
   Future<void> setPeriodCloseBannerHiddenUntil(DateTime? value);
@@ -58,9 +50,6 @@ class SqliteSettingsRepository implements SettingsRepository {
   static const String _periodCloseBannerHiddenUntilKey =
       'period_close_banner_hidden_until';
   static const String _defaultAccountIdKey = 'default_account_id';
-  static const String _defaultNecessityCriticalityKey =
-      'default_necessity_criticality';
-  static const String _defaultNecessityIdKey = 'default_necessity_id';
 
   final AppDatabase _database;
 
@@ -154,22 +143,6 @@ class SqliteSettingsRepository implements SettingsRepository {
   @override
   Future<void> setDefaultAccountId(int? value) =>
       _setNullableInt(_defaultAccountIdKey, value);
-
-  @override
-  Future<int> getDefaultNecessityCriticality() =>
-      _getInt(_defaultNecessityCriticalityKey, defaultValue: 0);
-
-  @override
-  Future<void> setDefaultNecessityCriticality(int value) =>
-      _setInt(_defaultNecessityCriticalityKey, value);
-
-  @override
-  Future<int?> getDefaultNecessityId() =>
-      _getNullableInt(_defaultNecessityIdKey);
-
-  @override
-  Future<void> setDefaultNecessityId(int? value) =>
-      _setNullableInt(_defaultNecessityIdKey, value);
 
   Future<int> _getInt(String key, {required int defaultValue}) async {
     final db = await _db;

--- a/lib/state/app_providers.dart
+++ b/lib/state/app_providers.dart
@@ -134,16 +134,6 @@ final defaultAccountIdProvider = FutureProvider<int?>((ref) async {
   return repository.getDefaultAccountId();
 });
 
-final defaultNecessityCriticalityProvider = FutureProvider<int>((ref) async {
-  final repository = ref.watch(settingsRepoProvider);
-  return repository.getDefaultNecessityCriticality();
-});
-
-final defaultNecessityIdProvider = FutureProvider<int?>((ref) async {
-  final repository = ref.watch(settingsRepoProvider);
-  return repository.getDefaultNecessityId();
-});
-
 final necessityRepoProvider = Provider<necessity_repo.NecessityRepository>((ref) {
   final database = ref.watch(appDatabaseProvider);
   return necessity_repo.NecessityRepositorySqlite(database: database);

--- a/lib/ui/settings/necessity_settings_screen.dart
+++ b/lib/ui/settings/necessity_settings_screen.dart
@@ -236,63 +236,54 @@ class _NecessitySettingsScreenState
 
           return Padding(
             padding: const EdgeInsets.all(16),
-            child: Column(
-              children: [
-                _buildDefaultsCard(context, labels),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: ReorderableListView.builder(
-                    itemCount: labels.length,
-                    onReorder: _handleReorder,
-                    buildDefaultDragHandles: false,
-                    proxyDecorator: (child, index, animation) => child,
-                    itemExtent: _itemHeight,
-                    itemBuilder: (context, index) {
-                      final label = labels[index];
-                      final hasColor = label.color?.trim().isNotEmpty == true;
-                      final color = hexToColor(label.color);
-                      return SizedBox(
-                        key: ValueKey(label.id),
-                        height: _itemHeight,
-                        child: Card(
-                          margin: EdgeInsets.zero,
-                          child: ListTile(
-                            leading: CircleAvatar(
-                              backgroundColor: color ??
-                                  Theme.of(context).colorScheme.surfaceVariant,
-                              child:
-                                  hasColor ? null : const Icon(Icons.block, size: 16),
-                            ),
-                            title: Text(label.name),
-                            trailing: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                ReorderableDragStartListener(
-                                  index: index,
-                                  child: const Icon(Icons.drag_handle),
-                                ),
-                                IconButton(
-                                  tooltip: 'Переименовать',
-                                  onPressed: () => showNecessityEditSheet(
-                                    context,
-                                    initial: label,
-                                  ),
-                                  icon: const Icon(Icons.edit),
-                                ),
-                                IconButton(
-                                  tooltip: 'Скрыть',
-                                  onPressed: () => _archiveLabel(label),
-                                  icon: const Icon(Icons.archive),
-                                ),
-                              ],
-                            ),
+            child: ReorderableListView.builder(
+              itemCount: labels.length,
+              onReorder: _handleReorder,
+              buildDefaultDragHandles: false,
+              proxyDecorator: (child, index, animation) => child,
+              itemExtent: _itemHeight,
+              itemBuilder: (context, index) {
+                final label = labels[index];
+                final hasColor = label.color?.trim().isNotEmpty == true;
+                final color = hexToColor(label.color);
+                return SizedBox(
+                  key: ValueKey(label.id),
+                  height: _itemHeight,
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    child: ListTile(
+                      leading: CircleAvatar(
+                        backgroundColor: color ??
+                            Theme.of(context).colorScheme.surfaceVariant,
+                        child: hasColor
+                            ? null
+                            : const Icon(Icons.block, size: 16),
+                      ),
+                      title: Text(label.name),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ReorderableDragStartListener(
+                            index: index,
+                            child: const Icon(Icons.drag_handle),
                           ),
-                        ),
-                      );
-                    },
+                          IconButton(
+                            tooltip: 'Переименовать',
+                            onPressed: () =>
+                                showNecessityEditSheet(context, initial: label),
+                            icon: const Icon(Icons.edit),
+                          ),
+                          IconButton(
+                            tooltip: 'Скрыть',
+                            onPressed: () => _archiveLabel(label),
+                            icon: const Icon(Icons.archive),
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
-                ),
-              ],
+                );
+              },
             ),
           );
         },
@@ -364,253 +355,6 @@ class _NecessitySettingsScreenState
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Метка "${label.name}" скрыта')),
     );
-  }
-
-  Widget _buildDefaultsCard(
-    BuildContext context,
-    List<NecessityLabel> labels,
-  ) {
-    final theme = Theme.of(context);
-    final defaultCriticalityAsync = ref.watch(defaultNecessityCriticalityProvider);
-    final defaultNecessityIdAsync = ref.watch(defaultNecessityIdProvider);
-    final defaultCriticality = defaultCriticalityAsync.valueOrNull ?? 0;
-    final defaultNecessityId = defaultNecessityIdAsync.valueOrNull;
-
-    String resolveCriticalitySubtitle() {
-      return defaultCriticalityAsync.when(
-        data: (value) {
-          if (labels.isEmpty) {
-            return 'Добавьте метки, чтобы выбрать критичность по умолчанию';
-          }
-          if (value < 0 || value >= labels.length) {
-            return 'Значение $value вне диапазона';
-          }
-          final label = labels[value];
-          return label.name;
-        },
-        loading: () => 'Загрузка…',
-        error: (error, _) => 'Не удалось загрузить: $error',
-      );
-    }
-
-    String resolveNecessitySubtitle() {
-      return defaultNecessityIdAsync.when(
-        data: (value) {
-          if (value == null) {
-            return 'Не выбрано';
-          }
-          final label = _findLabelById(labels, value);
-          if (label != null) {
-            return label.name;
-          }
-          return 'Метка недоступна';
-        },
-        loading: () => 'Загрузка…',
-        error: (error, _) => 'Не удалось загрузить: $error',
-      );
-    }
-
-    final canEditCriticality = labels.isNotEmpty && defaultCriticalityAsync.hasValue;
-    final canEditNecessity = labels.isNotEmpty && defaultNecessityIdAsync.hasValue;
-
-    return Card(
-      margin: EdgeInsets.zero,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ListTile(
-            title: const Text('Критичность по умолчанию'),
-            subtitle: Text(resolveCriticalitySubtitle()),
-            trailing: canEditCriticality ? const Icon(Icons.chevron_right) : null,
-            enabled: canEditCriticality,
-            onTap: canEditCriticality
-                ? () => _showDefaultCriticalityPicker(
-                      context,
-                      labels,
-                      defaultCriticality,
-                    )
-                : null,
-          ),
-          Divider(height: 0, color: theme.colorScheme.outlineVariant),
-          ListTile(
-            title: const Text('Необходимость по умолчанию'),
-            subtitle: Text(resolveNecessitySubtitle()),
-            enabled: canEditNecessity,
-            trailing: canEditNecessity
-                ? Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (defaultNecessityId != null)
-                        IconButton(
-                          tooltip: 'Сбросить',
-                          onPressed: () => _clearDefaultNecessity(context),
-                          icon: const Icon(Icons.clear),
-                        ),
-                      const Icon(Icons.chevron_right),
-                    ],
-                  )
-                : null,
-            onTap: canEditNecessity
-                ? () => _showDefaultNecessityPicker(
-                      context,
-                      labels,
-                      defaultNecessityId,
-                    )
-                : null,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _showDefaultCriticalityPicker(
-    BuildContext context,
-    List<NecessityLabel> labels,
-    int initial,
-  ) async {
-    if (labels.isEmpty) {
-      return;
-    }
-    final repository = ref.read(settingsRepoProvider);
-    final clampedInitial = initial.clamp(0, labels.length - 1);
-    var selectedIndex = clampedInitial;
-    final result = await showDialog<int>(
-      context: context,
-      builder: (dialogContext) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            return AlertDialog(
-              title: const Text('Критичность по умолчанию'),
-              content: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (var i = 0; i < labels.length; i++)
-                      RadioListTile<int>(
-                        title: Text(labels[i].name),
-                        value: i,
-                        groupValue: selectedIndex,
-                        onChanged: (value) {
-                          if (value != null) {
-                            setState(() => selectedIndex = value);
-                          }
-                        },
-                      ),
-                  ],
-                ),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Отмена'),
-                ),
-                FilledButton(
-                  onPressed: () => Navigator.of(context).pop(selectedIndex),
-                  child: const Text('Выбрать'),
-                ),
-              ],
-            );
-          },
-        );
-      },
-    );
-    if (result == null) {
-      return;
-    }
-    await repository.setDefaultNecessityCriticality(result);
-    ref.invalidate(defaultNecessityCriticalityProvider);
-    if (!mounted) {
-      return;
-    }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Критичность по умолчанию обновлена')),
-    );
-  }
-
-  Future<void> _showDefaultNecessityPicker(
-    BuildContext context,
-    List<NecessityLabel> labels,
-    int? initialId,
-  ) async {
-    if (labels.isEmpty) {
-      return;
-    }
-    final repository = ref.read(settingsRepoProvider);
-    var selectedId = initialId;
-    final result = await showDialog<int>(
-      context: context,
-      builder: (dialogContext) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            return AlertDialog(
-              title: const Text('Необходимость по умолчанию'),
-              content: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (final label in labels)
-                      RadioListTile<int>(
-                        title: Text(label.name),
-                        value: label.id,
-                        groupValue: selectedId,
-                        onChanged: (value) {
-                          if (value != null) {
-                            setState(() => selectedId = value);
-                          }
-                        },
-                      ),
-                  ],
-                ),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Отмена'),
-                ),
-                FilledButton(
-                  onPressed: selectedId == null
-                      ? null
-                      : () => Navigator.of(context).pop(selectedId),
-                  child: const Text('Выбрать'),
-                ),
-              ],
-            );
-          },
-        );
-      },
-    );
-    if (result == null) {
-      return;
-    }
-    await repository.setDefaultNecessityId(result);
-    ref.invalidate(defaultNecessityIdProvider);
-    if (!mounted) {
-      return;
-    }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Необходимость по умолчанию обновлена')),
-    );
-  }
-
-  Future<void> _clearDefaultNecessity(BuildContext context) async {
-    final repository = ref.read(settingsRepoProvider);
-    await repository.setDefaultNecessityId(null);
-    ref.invalidate(defaultNecessityIdProvider);
-    if (!mounted) {
-      return;
-    }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Необходимость по умолчанию сброшена')),
-    );
-  }
-
-  NecessityLabel? _findLabelById(List<NecessityLabel> labels, int id) {
-    for (final label in labels) {
-      if (label.id == id) {
-        return label;
-      }
-    }
-    return null;
   }
 
 }


### PR DESCRIPTION
## Summary
- remove default necessity criticality storage APIs from the settings repository
- simplify the necessity settings screen back to a plain reorderable list
- drop automatic seeding of default necessity labels in database migrations

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e52290b00c8326b15b908b2df9a321