### PR TITLE
Add dedicated seeder for default criticalities

### DIFF
--- a/lib/data/seed/seed_criticalities.dart
+++ b/lib/data/seed/seed_criticalities.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/foundation.dart';
+import 'package:sqflite/sqflite.dart';
+
+class SeedCriticalities {
+  const SeedCriticalities._();
+
+  static const _table = 'necessity_labels';
+
+  static const _defaults = <_CriticalityDefinition>[
+    _CriticalityDefinition('Точно', '#546E7A'),
+    _CriticalityDefinition('Надо', '#607D8B'),
+    _CriticalityDefinition('Можно отложить', '#78909C'),
+    _CriticalityDefinition('Заморожено', '#90A4AE'),
+    _CriticalityDefinition('Уже не надо', '#B0BEC5'),
+    _CriticalityDefinition('Хочу', '#CFD8DC'),
+  ];
+
+  static Future<void> run(DatabaseExecutor executor) async {
+    assert(() {
+      debugPrint('[seed] criticalities');
+      return true;
+    }());
+
+    final hasColor = await _hasColumn(executor, _table, 'color');
+    final hasSortOrder = await _hasColumn(executor, _table, 'sort_order');
+
+    for (var i = 0; i < _defaults.length; i++) {
+      final definition = _defaults[i];
+      final existing = await executor.query(
+        _table,
+        columns: const ['id'],
+        where: 'name = ?',
+        whereArgs: [definition.name],
+        limit: 1,
+      );
+      if (existing.isNotEmpty) {
+        continue;
+      }
+
+      final values = <String, Object?>{
+        'name': definition.name,
+        'archived': 0,
+      };
+      if (hasColor && definition.color != null) {
+        values['color'] = definition.color;
+      }
+      if (hasSortOrder) {
+        values['sort_order'] = (i + 1) * 10;
+      }
+
+      await executor.insert(
+        _table,
+        values,
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+    }
+  }
+
+  static Future<bool> _hasColumn(
+    DatabaseExecutor executor,
+    String table,
+    String column,
+  ) async {
+    final normalized = column.toLowerCase();
+    final result = await executor.rawQuery('PRAGMA table_info($table)');
+    return result.any(
+      (row) => (row['name'] as String?)?.toLowerCase() == normalized,
+    );
+  }
+}
+
+class _CriticalityDefinition {
+  const _CriticalityDefinition(this.name, this.color);
+
+  final String name;
+  final String? color;
+}

--- a/lib/data/seed/seed_data.dart
+++ b/lib/data/seed/seed_data.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:sqflite/sqflite.dart';
 
+import 'seed_criticalities.dart';
+
 /// Seeds default reference data for the application.
 class SeedData {
   SeedData._();
@@ -12,7 +14,7 @@ class SeedData {
     }());
 
     await seedCategories(db);
-    await seedCriticalities(db);
+    await SeedCriticalities.run(db);
     await seedReasons(db);
   }
 
@@ -159,54 +161,6 @@ class SeedData {
     }
   }
 
-  static Future<void> seedCriticalities(DatabaseExecutor executor) async {
-    assert(() {
-      debugPrint('[seed] criticalities');
-      return true;
-    }());
-
-    final hasColor = await _hasColumn(executor, 'necessity_labels', 'color');
-    final hasSortOrder = await _hasColumn(executor, 'necessity_labels', 'sort_order');
-
-    const items = <_LabelDefinition>[
-      _LabelDefinition('Точно', '#546E7A'),
-      _LabelDefinition('Надо', '#607D8B'),
-      _LabelDefinition('Можно отложить', '#78909C'),
-      _LabelDefinition('Заморожено', '#90A4AE'),
-      _LabelDefinition('Уже не надо', '#B0BEC5'),
-      _LabelDefinition('Хочу', '#CFD8DC'),
-    ];
-
-    for (var i = 0; i < items.length; i++) {
-      final item = items[i];
-      final existingId = await _getSimpleId(
-        executor,
-        table: 'necessity_labels',
-        name: item.name,
-      );
-      if (existingId != null) {
-        continue;
-      }
-
-      final values = <String, Object?>{
-        'name': item.name,
-        'archived': 0,
-      };
-      if (hasColor) {
-        values['color'] = item.color;
-      }
-      if (hasSortOrder) {
-        values['sort_order'] = (i + 1) * 10;
-      }
-
-      await executor.insert(
-        'necessity_labels',
-        values,
-        conflictAlgorithm: ConflictAlgorithm.ignore,
-      );
-    }
-  }
-
   static Future<void> seedReasons(DatabaseExecutor executor) async {
     assert(() {
       debugPrint('[seed] reasons');
@@ -287,11 +241,4 @@ class _FolderDefinition {
 
   final String name;
   final List<String> children;
-}
-
-class _LabelDefinition {
-  const _LabelDefinition(this.name, this.color);
-
-  final String name;
-  final String color;
 }


### PR DESCRIPTION
## Summary
- ensure the default criticality labels are seeded idempotently via the existing `necessity_labels` table
- invoke the new seeder from the shared seed routine so it runs on create and upgrade

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e524c515088326b015bef647ccce57